### PR TITLE
Return more useful objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.2.0-DEV"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+LogExpFunctions = "0.2.0, 0.3"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,17 @@ authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
 version = "0.1.1"
 
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+Distributions = "0.21.1, 0.22, 0.23, 0.24, 0.25"
 LogExpFunctions = "0.2.0, 0.3"
+StatsBase = "0.32, 0.33"
 julia = "1"
 
 [extras]

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -55,7 +55,8 @@ function Base.show(io::IO, ::MIME"text/plain", r::PSISResult{T}) where {T}
     println(io, typeof(r), ":")
     println(io, "    ndraws: ", r.ndraws)
     println(io, "    r_eff: ", r.r_eff)
-    return println(io, "    pareto_k: ", r.pareto_k)
+    print(io, "    pareto_k: ", r.pareto_k)
+    return nothing
 end
 
 """

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -7,13 +7,59 @@ using StatsBase: StatsBase
 using LinearAlgebra: dot
 using Printf: @sprintf
 
-export psis, psis!
+export PSISResult, psis, psis!
 
 include("utils.jl")
 include("generalized_pareto.jl")
 
 """
-    psis(log_ratios, r_eff; kwargs...) -> (log_weights, k)
+    PSISResult
+
+Result of Pareto-smoothed importance sampling (PSIS).
+
+# Properties
+
+  - `log_weights`: unnormalized Pareto-smoothed log weights
+  - `weights`: normalized Pareto-smoothed weights (allocates a copy)
+  - `ndraws`: length of `log_weights` and `weights`
+  - `pareto_k`: Pareto ``k=ξ`` shape parameter
+  - `r_eff`: the ratio of the effective sample size of the unsmoothed importance ratios and
+    the actual sample size.
+  - `tail_length`: length of the upper tail of `log_weights` that was smoothed
+  - `tail_dist`: the generalized Pareto distribution that was fit to the tail of `log_weights`
+
+See [`psis`](@ref) for a description of how to use `pareto_k` as a diagnostic.
+"""
+struct PSISResult{
+    T,W<:AbstractArray{T},R<:Real,D<:Union{Missing,Distributions.GeneralizedPareto{T}}
+}
+    log_weights::W
+    r_eff::R
+    tail_length::Int
+    tail_dist::D
+end
+
+function Base.getproperty(r::PSISResult, k::Symbol)
+    if k === :weights
+        log_weights = getfield(r, :log_weights)
+        return exp.(log_weights .- logsumexp(log_weights))
+    end
+    k === :ndraws && return length(getfield(r, :log_weights))
+    k === :pareto_k && return pareto_k(getfield(r, :tail_dist))
+    return getfield(r, k)
+end
+
+Base.propertynames(r::PSISResult) = [fieldnames(typeof(r))..., :weights, :pareto_k, :ndraws]
+
+function Base.show(io::IO, ::MIME"text/plain", r::PSISResult{T}) where {T}
+    println(io, typeof(r), ":")
+    println(io, "    ndraws: ", r.ndraws)
+    println(io, "    r_eff: ", r.r_eff)
+    return println(io, "    pareto_k: ", r.pareto_k)
+end
+
+"""
+    psis(log_ratios, r_eff; sorted=issorted(log_ratios)) -> PSISResult
 
 Compute Pareto smoothed importance sampling (PSIS) log weights [^VehtariSimpson2021].
 
@@ -29,22 +75,16 @@ See [`psis!`](@ref) for version that smoothes the ratios in-place.
     used to correct for autocorrelation due to MCMC. `r_eff=1` should be used if the ratios
     were sampled independently.
 
-# Keywords
-
-  - `sorted=issorted(log_ratios)`: whether `log_ratios` are already sorted.
-  - `normalize=false`: whether to normalize the log weights so that
-    `sum(exp.(low_weights)) ≈ 1`.
-
 # Returns
 
-  - `log_weights`: an array of smoothed log weights
-  - `k`: the estimated shape parameter ``k`` of the generalized Pareto distribution, which
-    is useful for diagnosing the distribution of importance ratios. See details below.
+  - `result::PSISResult`: The result of PSIS. See [`PSISResult`](@ref) for a description of
+    the properties.
 
 # Diagnostic
 
-The shape parameter ``k`` of the generalized Pareto distribution can be used to diagnose
-reliability and convergence of estimates using the importance weights [^VehtariSimpson2021]:
+The shape parameter ``k`` of the generalized Pareto distribution (accessed by
+`result.pareto_k`) can be used to diagnose reliability and convergence of estimates using
+the importance weights [^VehtariSimpson2021]:
 
   - if ``k < \\frac{1}{3}``, importance sampling is stable, and importance sampling (IS) and
     PSIS both are reliable.
@@ -61,57 +101,48 @@ reliability and convergence of estimates using the importance weights [^VehtariS
 
 A warning is raised if ``k ≥ 0.7``.
 """
-function psis(logr, r_eff=1.0; kwargs...)
+function psis(logr, r_eff; kwargs...)
     T = float(eltype(logr))
     logw = copyto!(similar(logr, T), logr)
     return psis!(logw, r_eff; kwargs...)
 end
 
 """
-    psis!(args...; kwargs...)
+    psis!(log_ratios, r_eff; sorted=issorted(log_ratios)) -> PSISResult
 
 In-place compute Pareto smoothed importance sampling (PSIS) log weights.
+
+The log importance ratios are overwritten by the (unnormalized) log importance weights,
+which are also contained within the returned [`PSISResult`](@ref) object.
 
 See [`psis`](@ref) for an out-of-place version and for description of arguments and return
 values.
 """
-function psis!(logw, r_eff=1.0; sorted=issorted(logw), normalize=false)
-    T = eltype(logw)
+function psis!(logw, r_eff; sorted=issorted(logw))
     S = length(logw)
-    k_hat = T(Inf)
-
     M = tail_length(r_eff, S)
+
     if M < 5
         @warn "Insufficient tail draws to fit the generalized Pareto distribution."
-    else
-        perm = sorted ? eachindex(logw) : sortperm(logw)
-        @inbounds logw_max = logw[last(perm)]
-        icut = S - M
-        tail_range = (icut + 1):S
-
-        @inbounds logw_tail = @views logw[perm[tail_range]]
-        if logw_max - first(logw_tail) < eps(eltype(logw_tail)) / 100
-            @warn "Cannot fit the generalized Pareto distribution because all tail " *
-                "values are the same"
-        else
-            logw_tail .-= logw_max
-            @inbounds logu = logw[perm[icut]] - logw_max
-
-            _, k_hat = psis_tail!(logw_tail, logu, M)
-            logw_tail .+= logw_max
-
-            check_pareto_k(k_hat)
-        end
+        return PSISResult(logw, r_eff, M, missing)
     end
 
-    if normalize
-        logw .-= logsumexp(logw)
-    end
-
-    return logw, k_hat
+    perm = sorted ? eachindex(logw) : sortperm(logw)
+    @inbounds logw_max = logw[last(perm)]
+    icut = S - M
+    tail_range = (icut + 1):S
+    @inbounds logw_tail = @views logw[perm[tail_range]]
+    @inbounds logμ = logw[perm[icut]]
+    _, tail_dist = psis_tail!(logw_tail, logμ; sorted=true)
+    check_tail_dist(tail_dist)
+    return PSISResult(logw, r_eff, M, tail_dist)
 end
 
-function check_pareto_k(k)
+pareto_k(d::Distributions.GeneralizedPareto) = d.ξ
+pareto_k(::Missing) = missing
+
+function check_tail_dist(d::Distributions.GeneralizedPareto)
+    k = pareto_k(d)
     if k ≥ 1
         @warn "Pareto k=$(@sprintf("%.2g", k)) ≥ 1. Resulting importance sampling " *
             "estimates are likely to be unstable and are unlikely to converge with " *
@@ -125,17 +156,26 @@ end
 
 tail_length(r_eff, S) = min(cld(S, 5), ceil(Int, 3 * sqrt(S / r_eff)))
 
-function psis_tail!(logw, logu, M=length(logw))
+function psis_tail!(logw, logμ; sorted=issorted(logw))
     T = eltype(logw)
-    u = exp(logu)
-    w = (logw .= exp.(logw) .- u)
-    d_hat = fit(GeneralizedPareto, w; sorted=true)
-    k_hat = T(d_hat.k)
-    if isfinite(k_hat)
+    M = length(logw)
+    sorted || sort!(logw)
+    logw_max = @inbounds logw[M]
+    # shift to fit zero-centered GPD and scale for increased numerical stability
+    μ_scaled = exp(logμ - logw_max)
+    # reuse storage
+    w = (logw .= exp.(logw .- logw_max) .- μ_scaled)
+    # fit tail distribution
+    method = EmpiricalBayesEstimate()
+    tail_dist = StatsBase.fit!(GeneralizedParetoKnownMu(zero(T)), w, method; sorted=true)
+    if isfinite(pareto_k(tail_dist))
         p = uniform_probabilities(T, M)
-        logw .= min.(log.(quantile.(Ref(d_hat), p) .+ u), zero(T))
+        # compute smoothed log-weights, undoing shift-and-scale
+        logw .= min.(log.(quantile.(Ref(tail_dist), p) .+ μ_scaled), 0) .+ logw_max
     end
-    return logw, k_hat
+    # undo shift-and-scale
+    tail_dist_trans = shift_then_scale(tail_dist, μ_scaled, exp(logw_max))
+    return logw, tail_dist_trans
 end
 
 end

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -128,8 +128,8 @@ function psis!(logw, r_eff; sorted::Bool=issorted(logw))
         return PSISResult(logw, r_eff, M, missing)
     end
 
-    perm = sorted ? eachindex(logw) : sortperm(logw)
     @inbounds logw_max = logw[last(perm)]
+    perm = sorted ? collect(eachindex(logw_vec)) : sortperm(logw_vec)
     icut = S - M
     tail_range = (icut + 1):S
     @inbounds logw_tail = @views logw[perm[tail_range]]

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -118,7 +118,7 @@ which are also contained within the returned [`PSISResult`](@ref) object.
 See [`psis`](@ref) for an out-of-place version and for description of arguments and return
 values.
 """
-function psis!(logw, r_eff; sorted=issorted(logw))
+function psis!(logw, r_eff; sorted::Bool=issorted(logw))
     S = length(logw)
     M = tail_length(r_eff, S)
 

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -1,7 +1,9 @@
 module PSIS
 
-using Statistics: mean
+using Distributions: Distributions
 using LogExpFunctions: logsumexp
+using Statistics: mean, quantile
+using StatsBase: StatsBase
 using LinearAlgebra: dot
 using Printf: @sprintf
 

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -9,35 +9,9 @@ using Printf: @sprintf
 
 export PSISResult, psis, psis!
 
-include("utils.jl")
-include("generalized_pareto.jl")
+abstract type AbstractISResult end
 
-"""
-    PSISResult
-
-Result of Pareto-smoothed importance sampling (PSIS).
-
-# Properties
-
-  - `log_weights`: unnormalized Pareto-smoothed log weights
-  - `weights`: normalized Pareto-smoothed weights (allocates a copy)
-  - `ndraws`: length of `log_weights` and `weights`
-  - `pareto_k`: Pareto ``k=ξ`` shape parameter
-  - `r_eff`: the ratio of the effective sample size of the unsmoothed importance ratios and
-    the actual sample size.
-  - `tail_length`: length of the upper tail of `log_weights` that was smoothed
-  - `tail_dist`: the generalized Pareto distribution that was fit to the tail of `log_weights`
-
-See [`psis`](@ref) for a description of how to use `pareto_k` as a diagnostic.
-"""
-struct PSISResult{T,W<:AbstractArray{T},R,L,D}
-    log_weights::W
-    r_eff::R
-    tail_length::L
-    tail_dist::D
-end
-
-function Base.getproperty(r::PSISResult, k::Symbol)
+function Base.getproperty(r::AbstractISResult, k::Symbol)
     if k === :weights
         log_weights = getfield(r, :log_weights)
         log_sum_weights = if ndims(log_weights) == 3
@@ -45,7 +19,11 @@ function Base.getproperty(r::PSISResult, k::Symbol)
         else
             logsumexp(log_weights)
         end
-        return exp.(log_weights .- log_sum_weights)
+        # for arrays with named axes and dimensions, this preserves the names
+        # in the result
+        weights = similar(log_weights)
+        weights .= exp.(log_weights .- log_sum_weights)
+        return weights
     end
     if k === :nparams
         log_weights = getfield(r, :log_weights)
@@ -60,156 +38,27 @@ function Base.getproperty(r::PSISResult, k::Symbol)
         d = ndims(log_weights)
         return d == 1 ? 1 : size(log_weights, d)
     end
-    k === :pareto_k && return pareto_k(getfield(r, :tail_dist))
+    k === :pareto_k && return pareto_k(r)
     return getfield(r, k)
 end
 
-function Base.propertynames(r::PSISResult)
-    return [fieldnames(typeof(r))..., :weights, :pareto_k, :nparams, :ndraws, :nchains]
+function Base.propertynames(r::AbstractISResult)
+    return [fieldnames(typeof(r))..., :weights, :nparams, :ndraws, :nchains]
 end
 
-function Base.show(io::IO, ::MIME"text/plain", r::PSISResult{T}) where {T}
+function Base.show(io::IO, ::MIME"text/plain", r::AbstractISResult)
     println(io, typeof(r), ":")
     println(io, "    (nparams, ndraws, nchains): ", (r.nparams, r.ndraws, r.nchains))
-    println(io, "    r_eff: ", r.r_eff)
-    print(io, "    pareto_k: ", r.pareto_k)
+    print(io, "    r_eff: ", r.r_eff)
     return nothing
 end
 
-"""
-    psis(log_ratios, r_eff; sorted=issorted(log_ratios)) -> PSISResult
+pareto_k(::AbstractISResult) = missing
 
-Compute Pareto smoothed importance sampling (PSIS) log weights [^VehtariSimpson2021].
-
-See [`psis!`](@ref) for version that smoothes the ratios in-place.
-
-[^VehtariSimpson2021]: Vehtari A, Simpson D, Gelman A, Yao Y, Gabry J. (2021).
-    Pareto smoothed importance sampling.
-    [arXiv:1507.02646v7](https://arxiv.org/abs/1507.02646v7) [stat.CO]
-# Arguments
-
-  - `log_ratios`: an array of logarithms of importance ratios.
-  - `r_eff`: the ratio of effective sample size of `log_ratios` and the actual sample size,
-    used to correct for autocorrelation due to MCMC. `r_eff=1` should be used if the ratios
-    were sampled independently.
-
-# Returns
-
-  - `result::PSISResult`: The result of PSIS. See [`PSISResult`](@ref) for a description of
-    the properties.
-
-# Diagnostic
-
-The shape parameter ``k`` of the generalized Pareto distribution (accessed by
-`result.pareto_k`) can be used to diagnose reliability and convergence of estimates using
-the importance weights [^VehtariSimpson2021]:
-
-  - if ``k < \\frac{1}{3}``, importance sampling is stable, and importance sampling (IS) and
-    PSIS both are reliable.
-  - if ``k < \\frac{1}{2}``, then the importance ratio distributon has finite variance, and
-    the central limit theorem holds. As ``k`` approaches the upper bound, IS becomes less
-    reliable, while PSIS still works well but with a higher RMSE.
-  - if ``\\frac{1}{2} ≤ k < 0.7``, then the variance is infinite, and IS can behave quite
-    poorly. However, PSIS works well in this regime.
-  - if ``0.7 ≤ k < 1``, then it quickly becomes impractical to collect enough importance
-    weights to reliably compute estimates, and importance sampling is not recommended.
-  - if ``k ≥ 1``, then neither the variance nor the mean of the raw importance ratios
-    exists. The convergence rate is close to zero, and bias can be large with practical
-    sample sizes.
-
-A warning is raised if ``k ≥ 0.7``.
-"""
-function psis(logr, r_eff; kwargs...)
-    T = float(eltype(logr))
-    logw = copyto!(similar(logr, T), logr)
-    return psis!(logw, r_eff; kwargs...)
-end
-
-"""
-    psis!(log_ratios, r_eff; sorted=issorted(log_ratios)) -> PSISResult
-
-In-place compute Pareto smoothed importance sampling (PSIS) log weights.
-
-The log importance ratios are overwritten by the (unnormalized) log importance weights,
-which are also contained within the returned [`PSISResult`](@ref) object.
-
-See [`psis`](@ref) for an out-of-place version and for description of arguments and return
-values.
-"""
-function psis!(logw, r_eff; sorted::Bool=issorted(logw))
-    S = length(logw)
-    M = tail_length(r_eff[1], S)
-
-    if M < 5
-        @warn "Insufficient tail draws to fit the generalized Pareto distribution."
-        return PSISResult(logw, r_eff, M, missing)
-    end
-
-    logw_vec = vec(logw)
-    perm = sorted ? collect(eachindex(logw_vec)) : sortperm(logw_vec)
-    @inbounds logw_max = logw_vec[last(perm)]
-    icut = S - M
-    tail_range = (icut + 1):S
-    @inbounds logw_tail = @views logw_vec[perm[tail_range]]
-    @inbounds logμ = logw_vec[perm[icut]]
-    _, tail_dist = psis_tail!(logw_tail, logμ; sorted=true)
-    check_tail_dist(tail_dist)
-
-    return PSISResult(logw, r_eff, M, tail_dist)
-end
-function psis!(logw::AbstractArray{T,3}, r_eff::AbstractVector) where {T}
-    nparams = size(logw, 1)
-    @assert nparams == length(r_eff)
-    tail_dists = Vector{Distributions.GeneralizedPareto{T}}(undef, nparams)
-    tail_lengths = Vector{Int}(undef, nparams)
-    Threads.@threads for i in 1:nparams
-        logwᵢ = @views logw[i, :, :]
-        res = psis!(logwᵢ, r_eff[i])
-        tail_dists[i] = res.tail_dist
-        tail_lengths[i] = res.tail_length
-    end
-    return PSISResult(logw, r_eff, tail_lengths, tail_dists)
-end
-
-pareto_k(d::Distributions.GeneralizedPareto) = d.ξ
-pareto_k(::Missing) = missing
-pareto_k(ds::AbstractVector) = map(pareto_k, ds)
-
-function check_tail_dist(d::Distributions.GeneralizedPareto)
-    k = pareto_k(d)
-    if k ≥ 1
-        @warn "Pareto k=$(@sprintf("%.2g", k)) ≥ 1. Resulting importance sampling " *
-            "estimates are likely to be unstable and are unlikely to converge with " *
-            "additional samples."
-    elseif k ≥ 0.7
-        @warn "Pareto k=$(@sprintf("%.2g", k)) ≥ 0.7. Resulting importance sampling " *
-            "estimates are likely to be unstable."
-    end
-    return nothing
-end
-
-tail_length(r_eff, S) = min(cld(S, 5), ceil(Int, 3 * sqrt(S / r_eff)))
-
-function psis_tail!(logw, logμ; sorted=issorted(logw))
-    T = eltype(logw)
-    M = length(logw)
-    sorted || sort!(logw)
-    logw_max = @inbounds logw[M]
-    # shift to fit zero-centered GPD and scale for increased numerical stability
-    μ_scaled = exp(logμ - logw_max)
-    # reuse storage
-    w = (logw .= exp.(logw .- logw_max) .- μ_scaled)
-    # fit tail distribution
-    method = EmpiricalBayesEstimate()
-    tail_dist = StatsBase.fit!(GeneralizedParetoKnownMu(zero(T)), w, method; sorted=true)
-    if isfinite(pareto_k(tail_dist))
-        p = uniform_probabilities(T, M)
-        # compute smoothed log-weights, undoing shift-and-scale
-        logw .= min.(log.(quantile.(Ref(tail_dist), p) .+ μ_scaled), 0) .+ logw_max
-    end
-    # undo shift-and-scale
-    tail_dist_trans = shift_then_scale(tail_dist, μ_scaled, exp(logw_max))
-    return logw, tail_dist_trans
-end
+include("utils.jl")
+include("generalized_pareto.jl")
+include("standard.jl")
+include("truncated.jl")
+include("smoothed.jl")
 
 end

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -1,6 +1,7 @@
 module PSIS
 
 using Statistics: mean
+using LogExpFunctions: logsumexp
 using LinearAlgebra: dot
 using Printf: @sprintf
 

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -1,55 +1,39 @@
-# Note: These internal functions are here to avoid a dependency on Distributions.jl,
-# which currently does not implement GPD fitting anyways. They are not methods of
-# functions in Statistics/StatsBase
-
-"""
-    GeneralizedPareto{T<:Real}
-
-The (zero-centered) generalized Pareto distribution.
-
-# Constructor
-
-    GeneralizedPareto(σ, k)
-
-Construct the generalized Pareto distribution (GPD) with scale parameter ``σ`` and shape
-parameter ``k``. Note that this ``k`` is equal to the commonly used shape parameter ``ξ``.
-This is the same parameterization used by [^VehtariSimpson2021] and is related to that used
-by [^ZhangStephens2009] as ``k \\mapsto -k``.
-"""
-struct GeneralizedPareto{T}
-    σ::T
-    k::T
+function shift_then_scale(d::Distributions.GeneralizedPareto, shift, scale)
+    return Distributions.GeneralizedPareto((d.μ + shift) * scale, d.σ * scale, d.ξ)
 end
-GeneralizedPareto(σ, k) = GeneralizedPareto(Base.promote(σ, k)...)
 
-"""
-    quantile(d::GeneralizedPareto, p)
+struct EmpiricalBayesEstimate end
 
-Compute the ``p``-quantile of the generalized Pareto distribution `d`.
-"""
-@inline function quantile(d::GeneralizedPareto, p)
-    k = d.k
-    z = -log1p(-p)
-    return iszero(k) ? d.σ * z : expm1(k * z) * (d.σ / k)
+struct GeneralizedParetoKnownMu{T} <: Distributions.IncompleteDistribution
+    μ::T
 end
 
 """
-    fit(T::Type{<:GeneralizedPareto}, x; kwargs...) -> ::T
+    StatsBase.fit!(
+        d::GeneralizedParetoKnownMu,
+        x,
+        method::EmpiricalBayesEstimate;
+        kwargs...,
+    ) -> ::Distributions.GeneralizedPareto
 
-Estimate a generalized Pareto distribution (GPD) given the points `x`.
+Estimate a generalized Pareto distribution (GPD) given the points `x` and mean `d.μ`.
 
-Compute an empirical Bayes estimate of the parameters of the (zero-centered) GPD given the
-data `x` using the method described in [^ZhangStephens2009]. The method estimates ``θ = \\frac{σ}{k}``
+Compute an empirical Bayes estimate of the scale parameter ``σ`` and shape parameter ``ξ``
+of the GPD given the data ``x`` and known mean ``μ`` using the method described in
+[^ZhangStephens2009]. The method assumes all elements of ``x`` are greater than ``μ``.
+If necessary, `x` is modified in-place during the fitting procedure.
+
+Note that ``ξ`` here is related to ``k`` in [^ZhangStephens2009] by ``ξ = -k``.
 
 # Keywords
 
-  - `sorted=false`: whether `x` is already sorted
+  - `sorted=false`: whether `x` is already sorted. If `false`, it will be sorted in-place.
   - `min_points=30`: default number of points to use to compute estimate.
     Instead of `min_points=20` as recommended by [^ZhangStephens2009], we use 30 points
-    as in the loo software. [^ZhangStephens2009] notes that the estimator is not sensitive
+    as in the loo package. [^ZhangStephens2009] notes that the estimator is not sensitive
     to this choice.
-  - `adjust_prior=true`: whether to apply the weakly informative Gaussian prior on `k`
-    suggested by [^VehtariSimpson2021] to reduce variance in the estimate of `k`.
+  - `adjust_prior=true`: whether to apply the weakly informative Gaussian prior on ``ξ``
+    suggested by [^VehtariSimpson2021] to reduce variance in the estimate of ``ξ``.
 
 [^ZhangStephens2009]: Zhang J & Stephens M A. (2009).
     A new and efficient estimation method for the generalized Pareto distribution,
@@ -59,31 +43,50 @@ data `x` using the method described in [^ZhangStephens2009]. The method estimate
     Pareto smoothed importance sampling.
     [arXiv:1507.02646v7](https://arxiv.org/abs/1507.02646v7) [stat.CO]
 """
-function fit(::Type{<:GeneralizedPareto}, x; sorted=false, min_points=30, adjust_prior=true)
-    x = sorted ? x : sort(x)
+function StatsBase.fit!(
+    d::GeneralizedParetoKnownMu,
+    x,
+    ::EmpiricalBayesEstimate;
+    sorted=false,
+    min_points=30,
+    adjust_prior=true,
+)
     n = length(x)
+    μ = d.μ
+    T = Base.promote_eltype(x, μ)
+    sorted || sort!(x)
+    # shift the data to fit the zero-centered GPD
+    if !iszero(μ)
+        x .-= μ
+    end
+    if last(x) ≤ first(x) * exp(eps(T) / 100)
+        # support is nearly a point. solution is not unique; any solution satisfying the
+        # constraints σ/ξ ≈ 0 and ξ < 0 is acceptable
+        return Distributions.GeneralizedPareto(T(μ), one(T), -T(Inf))
+    end
+    # fit the zero-centered GPD
     m = min_points + floor(Int, sqrt(n))
-    θ_hat = fit_θ(x, m)
-    k_hat = fit_k(x, θ_hat)
-    σ_hat = fit_σ(θ_hat, k_hat)
-    # NOTE: the paper is ambiguous whether the adjustment is applied to k_hat
+    θ_hat = _fit_θ(x, m) # θ = σ / ξ
+    ξ_hat = _fit_ξ(x, θ_hat)
+    σ_hat = _fit_σ(θ_hat, ξ_hat)
+    # NOTE: the paper is ambiguous whether the adjustment is applied to ξ_hat
     # before or after computing σ_hat. From private discussion with Aki Vehtari,
     # adjusting afterwards produces better results.
-    k_hat = adjust_prior ? prior_adjust_k(k_hat, n) : k_hat
-    return GeneralizedPareto(σ_hat, k_hat)
+    ξ_hat = adjust_prior ? prior_adjust_ξ(ξ_hat, n) : ξ_hat
+    return Distributions.GeneralizedPareto(μ, σ_hat, ξ_hat)
 end
 
 # estimate θ̂ = ∫θp(θ|x)dθ using quadrature over m grid points
 # uniformly sampled over the empirical prior
-function fit_θ(x, m)
+function _fit_θ(x, m)
     T = float(eltype(x))
     n = length(x)
 
     # construct empirical prior on y = 1/x[n] - θ
     x_star = quartile(x, 1)
     σ_star = inv(6 * x_star)
-    k_star = 1//2
-    y_prior = GeneralizedPareto(σ_star, k_star)
+    ξ_star = 1//2
+    y_prior = Distributions.GeneralizedPareto(zero(T), σ_star, ξ_star)
 
     # quadrature points uniformly spaced on the quantiles of the θ prior
     p = uniform_probabilities(T, m)
@@ -102,20 +105,21 @@ function fit_θ(x, m)
 end
 
 # Zhang & Stephens, Eq 7
-function fit_k(x, θ_hat)
+function _fit_ξ(x, θ_hat)
     nθ_hat = -θ_hat
     return mean(xᵢ -> log1p(nθ_hat * xᵢ), x)
 end
-fit_σ(θ_hat, k_hat) = -k_hat / θ_hat
 
-# compute likelihood p(x|θ,k), estimating k from θ
+_fit_σ(θ_hat, ξ_hat) = -ξ_hat / θ_hat
+
+# compute likelihood p(x|θ,ξ), estimating ξ from θ
 function profile_loglikelihood(θ, x, n=length(x))
-    # estimate k given θ
-    nk_est = -fit_k(x, θ)
-    return n * (log(θ / nk_est) + nk_est - 1)
+    # estimate ξ given θ
+    nξ_est = -_fit_ξ(x, θ)
+    return n * (log(θ / nξ_est) + nξ_est - 1)
 end
 
-# reduce variance of estimated k using a weakly informative Gaussian prior
-# centered at `k_prior` corresponding to `nobs` observations
+# reduce variance of estimated ξ using a weakly informative Gaussian prior
+# centered at `ξ_prior` corresponding to `nobs` observations
 # Vehtari et al, Appendix C
-prior_adjust_k(k, n, k_prior=1//2, nobs=10) = (n * k + nobs * k_prior) / (n + nobs)
+prior_adjust_ξ(ξ, n, ξ_prior=1//2, nobs=10) = (n * ξ + nobs * ξ_prior) / (n + nobs)

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -1,3 +1,4 @@
+# compute (d + shift) * scale but return GeneralizedPareto instead of LocationScale
 function shift_then_scale(d::Distributions.GeneralizedPareto, shift, scale)
     return Distributions.GeneralizedPareto((d.μ + shift) * scale, d.σ * scale, d.ξ)
 end
@@ -14,7 +15,7 @@ end
         x,
         method::EmpiricalBayesEstimate;
         kwargs...,
-    ) -> ::Distributions.GeneralizedPareto
+    ) -> Distributions.GeneralizedPareto
 
 Estimate a generalized Pareto distribution (GPD) given the points `x` and mean `d.μ`.
 

--- a/src/smoothed.jl
+++ b/src/smoothed.jl
@@ -1,0 +1,180 @@
+"""
+    PSISResult
+
+Result of Pareto-smoothed importance sampling (PSIS).
+
+# Properties
+
+  - `log_weights`: unnormalized Pareto-smoothed log weights
+  - `weights`: normalized Pareto-smoothed weights (allocates a copy)
+  - `ndraws`: length of `log_weights` and `weights`
+  - `pareto_k`: Pareto ``k=ξ`` shape parameter
+  - `r_eff`: the ratio of the effective sample size of the unsmoothed importance ratios and
+    the actual sample size.
+  - `tail_length`: length of the upper tail of `log_weights` that was smoothed
+  - `tail_dist`: the generalized Pareto distribution that was fit to the tail of `log_weights`
+
+See [`psis`](@ref) for a description of how to use `pareto_k` as a diagnostic.
+"""
+struct PSISResult{T,W<:AbstractArray{T},R,L,D} <: AbstractISResult
+    log_weights::W
+    r_eff::R
+    tail_length::L
+    tail_dist::D
+end
+
+function Base.propertynames(r::PSISResult)
+    return [fieldnames(typeof(r))..., :weights, :nparams, :ndraws, :nchains, :pareto_k]
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", r::PSISResult)
+    invoke(Base.show, Tuple{IO,typeof(mime),AbstractISResult}, io, mime, r)
+    print(io, "\n    pareto_k: ", r.pareto_k)
+    return nothing
+end
+
+"""
+    psis(log_ratios, r_eff; sorted=issorted(log_ratios)) -> PSISResult
+
+Compute Pareto smoothed importance sampling (PSIS) log weights [^VehtariSimpson2021].
+
+See [`psis!`](@ref) for version that smoothes the ratios in-place.
+
+[^VehtariSimpson2021]: Vehtari A, Simpson D, Gelman A, Yao Y, Gabry J. (2021).
+    Pareto smoothed importance sampling.
+    [arXiv:1507.02646v7](https://arxiv.org/abs/1507.02646v7) [stat.CO]
+# Arguments
+
+  - `log_ratios`: an array of logarithms of importance ratios.
+  - `r_eff`: the ratio of effective sample size of `log_ratios` and the actual sample size,
+    used to correct for autocorrelation due to MCMC. `r_eff=1` should be used if the ratios
+    were sampled independently.
+
+# Returns
+
+  - `result::PSISResult`: The result of PSIS. See [`PSISResult`](@ref) for a description of
+    the properties.
+
+# Diagnostic
+
+The shape parameter ``k`` of the generalized Pareto distribution (accessed by
+`result.pareto_k`) can be used to diagnose reliability and convergence of estimates using
+the importance weights [^VehtariSimpson2021]:
+
+  - if ``k < \\frac{1}{3}``, importance sampling is stable, and importance sampling (IS) and
+    PSIS both are reliable.
+  - if ``k < \\frac{1}{2}``, then the importance ratio distributon has finite variance, and
+    the central limit theorem holds. As ``k`` approaches the upper bound, IS becomes less
+    reliable, while PSIS still works well but with a higher RMSE.
+  - if ``\\frac{1}{2} ≤ k < 0.7``, then the variance is infinite, and IS can behave quite
+    poorly. However, PSIS works well in this regime.
+  - if ``0.7 ≤ k < 1``, then it quickly becomes impractical to collect enough importance
+    weights to reliably compute estimates, and importance sampling is not recommended.
+  - if ``k ≥ 1``, then neither the variance nor the mean of the raw importance ratios
+    exists. The convergence rate is close to zero, and bias can be large with practical
+    sample sizes.
+
+A warning is raised if ``k ≥ 0.7``.
+"""
+function psis(logr, r_eff; kwargs...)
+    T = float(eltype(logr))
+    logw = copyto!(similar(logr, T), logr)
+    return psis!(logw, r_eff; kwargs...)
+end
+
+"""
+    psis!(log_ratios, r_eff; sorted=issorted(log_ratios)) -> PSISResult
+
+In-place compute Pareto smoothed importance sampling (PSIS) log weights.
+
+The log importance ratios are overwritten by the (unnormalized) log importance weights,
+which are also contained within the returned [`PSISResult`](@ref) object.
+
+See [`psis`](@ref) for an out-of-place version and for description of arguments and return
+values.
+"""
+function psis!(logw, r_eff; sorted::Bool=issorted(logw))
+    S = length(logw)
+    M = tail_length(r_eff[1], S)
+
+    if M < 5
+        @warn "Insufficient tail draws to fit the generalized Pareto distribution."
+        return PSISResult(logw, r_eff, M, missing)
+    end
+
+    logw_vec = vec(logw)
+    perm = sorted ? collect(eachindex(logw_vec)) : sortperm(logw_vec)
+    @inbounds logw_max = logw_vec[last(perm)]
+    icut = S - M
+    tail_range = (icut + 1):S
+    @inbounds logw_tail = @views logw_vec[perm[tail_range]]
+    @inbounds logμ = logw_vec[perm[icut]]
+    _, tail_dist = psis_tail!(logw_tail, logμ; sorted=true)
+    check_tail_dist(tail_dist)
+
+    return PSISResult(logw, r_eff, M, tail_dist)
+end
+function psis!(logw::AbstractArray{T,3}, r_eff::AbstractVector) where {T}
+    nparams = size(logw, 1)
+    @assert nparams == length(r_eff)
+    tail_dists = Vector{Distributions.GeneralizedPareto{T}}(undef, nparams)
+    tail_lengths = Vector{Int}(undef, nparams)
+    Threads.@threads for i in 1:nparams
+        logwᵢ = @views logw[i, :, :]
+        res = psis!(logwᵢ, r_eff[i])
+        tail_dists[i] = res.tail_dist
+        tail_lengths[i] = res.tail_length
+    end
+    return PSISResult(logw, r_eff, tail_lengths, tail_dists)
+end
+
+pareto_k(d::Distributions.GeneralizedPareto) = d.ξ
+pareto_k(::Missing) = missing
+pareto_k(ds::AbstractVector) = map(pareto_k, ds)
+function pareto_k(res::PSISResult)
+    kvals = pareto_k(getfield(res, :tail_dist))
+    kvals isa AbstractVector || return kvals
+    # for arrays with named axes and dimensions, this preserves the names
+    # in the result
+    log_weights = getfield(res, :log_weights)
+    k = similar(view(log_weights, :, 1, 1))
+    copyto!(k, kvals)
+    return k
+end
+
+function check_tail_dist(d::Distributions.GeneralizedPareto)
+    k = pareto_k(d)
+    if k ≥ 1
+        @warn "Pareto k=$(@sprintf("%.2g", k)) ≥ 1. Resulting importance sampling " *
+            "estimates are likely to be unstable and are unlikely to converge with " *
+            "additional samples."
+    elseif k ≥ 0.7
+        @warn "Pareto k=$(@sprintf("%.2g", k)) ≥ 0.7. Resulting importance sampling " *
+            "estimates are likely to be unstable."
+    end
+    return nothing
+end
+
+tail_length(r_eff, S) = min(cld(S, 5), ceil(Int, 3 * sqrt(S / r_eff)))
+
+function psis_tail!(logw, logμ; sorted=issorted(logw))
+    T = eltype(logw)
+    M = length(logw)
+    sorted || sort!(logw)
+    logw_max = @inbounds logw[M]
+    # shift to fit zero-centered GPD and scale for increased numerical stability
+    μ_scaled = exp(logμ - logw_max)
+    # reuse storage
+    w = (logw .= exp.(logw .- logw_max) .- μ_scaled)
+    # fit tail distribution
+    method = EmpiricalBayesEstimate()
+    tail_dist = StatsBase.fit!(GeneralizedParetoKnownMu(zero(T)), w, method; sorted=true)
+    if isfinite(pareto_k(tail_dist))
+        p = uniform_probabilities(T, M)
+        # compute smoothed log-weights, undoing shift-and-scale
+        logw .= min.(log.(quantile.(Ref(tail_dist), p) .+ μ_scaled), 0) .+ logw_max
+    end
+    # undo shift-and-scale
+    tail_dist_trans = shift_then_scale(tail_dist, μ_scaled, exp(logw_max))
+    return logw, tail_dist_trans
+end

--- a/src/standard.jl
+++ b/src/standard.jl
@@ -1,0 +1,7 @@
+struct SISResult{T,W<:AbstractArray{T},R} <: AbstractISResult
+    log_weights::W
+    r_eff::R
+end
+
+sis(logr, r_eff) = sis!(logr, r_eff)
+sis!(logw, r_eff) = SISResult(logw, r_eff)

--- a/src/truncated.jl
+++ b/src/truncated.jl
@@ -1,0 +1,34 @@
+struct TISResult{T,W<:AbstractArray{T},R} <: AbstractISResult
+    log_weights::W
+    r_eff::R
+    log_weights_max::T
+end
+
+function tis(logr, r_eff)
+    T = float(eltype(logr))
+    logw = copyto!(similar(logr, T), logr)
+    return tis!(logw, r_eff)
+end
+function tis!(logw::AbstractVecOrMat, r_eff)
+    S = length(logw)
+    logsumw = logsumexp(logw)
+    logw_max = logsumw - log(oftype(logsumw, S)) / 2 # log(mean(r) * sqrt(S))
+    logw .= min.(logw, logw_max)
+    return TISResult(logw, r_eff, logw_max)
+end
+function tis!(logw::AbstractArray{T,3}, r_eff) where {T}
+    nparams = size(logw, 1)
+    logw_max = Vector{T}(undef, nparams)
+    Threads.@threads for i in 1:nparams
+        logwᵢ = @views logw[i, :, :]
+        res = tis!(logwᵢ, r_eff[i])
+        logw_max[i] = res.logw_max
+    end
+    return TISResult(logw, r_eff, logw_max)
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", r::TISResult)
+    invoke(Base.show, Tuple{IO,typeof(mime),AbstractISResult}, io, mime, r)
+    print(io, "\n    log_weights_max: ", r.log_weights_max)
+    return nothing
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,9 +1,3 @@
-# added here to avoid a dependency on LogExpFunctions
-function logsumexp(x)
-    xmax = maximum(x)
-    return log(sum(xᵢ -> exp(xᵢ - xmax), x)) + xmax
-end
-
 uniform_probabilities(T, npoints::Integer) = ((1:npoints) .- T(1//2)) ./ npoints
 
 # p-th quartile of x, assuming x is sorted in increasing order

--- a/test/generalized_pareto.jl
+++ b/test/generalized_pareto.jl
@@ -1,5 +1,7 @@
+using Distributions
 using PSIS
 using Random
+using StatsBase
 using Test
 
 @testset "Generalized Pareto distribution" begin
@@ -8,12 +10,28 @@ using Test
         # the original parameters are approximately recovered
         Random.seed!(42)
         u = rand(200_000)
-        @testset for σ in (0.5, 1.0, 2.0), k in (-1.0, 0.0, 0.3, 1.0, 2.0)
-            d = PSIS.GeneralizedPareto(σ, k)
-            x = PSIS.quantile.(Ref(d), u)
-            dhat = PSIS.fit(PSIS.GeneralizedPareto, x; adjust_prior=false, min_points=80)
+        @testset for μ in (0.0, -1.0, 2.0),
+            σ in (0.5, 1.0, 2.0),
+            ξ in (-1.0, 0.0, 0.3, 1.0, 2.0)
+
+            d = GeneralizedPareto(μ, σ, ξ)
+            x = quantile.(Ref(d), u)
+            dic = PSIS.GeneralizedParetoKnownMu(μ)
+            method = PSIS.EmpiricalBayesEstimate()
+            dhat = StatsBase.fit!(dic, x, method; adjust_prior=false, min_points=80)
+            @test dhat.μ == μ
             @test dhat.σ ≈ σ atol = 0.01
-            @test dhat.k ≈ k atol = 0.01
+            @test dhat.ξ ≈ ξ atol = 0.01
         end
+    end
+    @testset "" begin
+        d = GeneralizedPareto(1.1, 1.0, -Inf)
+        x = rand(d, 1_000)
+        dic = PSIS.GeneralizedParetoKnownMu(1.1)
+        method = PSIS.EmpiricalBayesEstimate()
+        dhat = StatsBase.fit!(dic, x, method)
+        @test dhat.μ == 1.1
+        @test dhat.σ == 1.0
+        @test dhat.ξ == -Inf
     end
 end

--- a/test/psis.jl
+++ b/test/psis.jl
@@ -63,10 +63,9 @@ end
             perm = sortperm(x)
             res = psis(x, 1.0)
             res_perm = psis(x[perm], 1.0; sorted=true)
-            @test res.log_weights == invpermute!(copy(res_perm.log_weights), perm)
-            @test res.weights == invpermute!(copy(res_perm.weights), perm)
-            @test res.pareto_k == res_perm.pareto_k
-            @test res.pareto_k == res_perm.pareto_k
+            @test res.log_weights ≈ invpermute!(copy(res_perm.log_weights), perm)
+            @test res.weights ≈ invpermute!(copy(res_perm.weights), perm)
+            @test res.pareto_k ≈ res_perm.pareto_k
         end
     end
 


### PR DESCRIPTION
For testing and visualization purposes, it is attractive to return a `PSISResult` object that contains intermediate computed quantities, as well as a plottable GPD distribution object. This PR refactors the internals of PSIS.jl to represent the GPD distribution using `Distributions.GeneralizedPareto`. This is stored in a new `PSISResult` object, which is returned.

Because this PR adds dependencies not in the standard library, package load time increases from 0.02s to 0.76 s on my machine. Considering that the new dependencies (Distributions and some of its dependencies) are widely used, this will likely not add additional dependencies for most potential dependants.