### PR TITLE
Add single-argument method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -103,7 +103,8 @@ function psis!(
     k_hat = T(Inf)
 
     @assert isone(length(reff)) # support numbers or single-element array
-    M = tail_length(first(reff), S)
+    reff_val = first(reff)
+    M = tail_length(reff_val, S)
     if M < 5
         @warn "Insufficient tail draws to fit the generalized Pareto distribution."
     else

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -81,14 +81,14 @@ A warning is raised if ``k ≥ 0.7``.
     Technometrics, 52:3, 335-339,
     DOI: [10.1198/TECH.2010.09206](https://doi.org/10.1198/TECH.2010.09206)
 """
-function psis(logr, r_eff; kwargs...)
+function psis(logr, reff=1; kwargs...)
     T = float(eltype(logr))
     logw = copyto!(similar(logr, T), logr)
-    return psis!(logw, r_eff; kwargs...)
+    return psis!(logw, reff; kwargs...)
 end
 
 """
-    psis!(args, r_eff; kwargs...)
+    psis!(args[, reff=1.0]; kwargs...)
 
 In-place compute Pareto smoothed importance sampling (PSIS) log weights.
 
@@ -96,14 +96,14 @@ See [`psis`](@ref) for an out-of-place version and for description of arguments 
 values.
 """
 function psis!(
-    logw::AbstractVector, r_eff; sorted=issorted(logw), normalize=false, improved=false
+    logw::AbstractVector, reff=1; sorted=issorted(logw), normalize=false, improved=false
 )
     T = eltype(logw)
     S = length(logw)
     k_hat = T(Inf)
 
-    @assert isone(length(r_eff)) # support numbers or single-element array
-    M = tail_length(first(r_eff), S)
+    @assert isone(length(reff)) # support numbers or single-element array
+    M = tail_length(first(reff), S)
     if M < 5
         @warn "Insufficient tail draws to fit the generalized Pareto distribution."
     else
@@ -133,14 +133,16 @@ function psis!(
 
     return logw, k_hat
 end
-function psis!(logw::AbstractArray, r_eff; kwargs...)
+function psis!(logw::AbstractArray, reff=1; kwargs...)
+    logw_firstcol = view(logw, :, ntuple(_ -> 1, ndims(logw) - 1)...)
+    reff_vec = reff isa Number ? fill!(similar(logw_firstcol), reff) : reff
     # support both 2D and 3D arrays, flattening the final dimension
-    _, k_hat = psis!(vec(selectdim(logw, 1, 1)), r_eff[1]; kwargs...)
+    _, k_hat = psis!(vec(selectdim(logw, 1, 1)), reff_vec[1]; kwargs...)
     # for arrays with named dimensions, this pattern ensures k_hat has the same names
-    k_hats = similar(view(logw, :, ntuple(_ -> 1, ndims(logw) - 1)...), eltype(k_hat))
+    k_hats = similar(logw_firstcol, eltype(k_hat))
     k_hats[1] = k_hat
-    Threads.@threads for i in eachindex(k_hats, r_eff)
-        _, k_hats[i] = psis!(vec(selectdim(logw, 1, i)), r_eff[i]; kwargs...)
+    Threads.@threads for i in eachindex(k_hats, reff_vec)
+        _, k_hats[i] = psis!(vec(selectdim(logw, 1, i)), reff_vec[i]; kwargs...)
     end
     return logw, k_hats
 end
@@ -157,7 +159,7 @@ function check_pareto_k(k)
     return nothing
 end
 
-tail_length(r_eff, S) = min(cld(S, 5), ceil(Int, 3 * sqrt(S / r_eff)))
+tail_length(reff, S) = min(cld(S, 5), ceil(Int, 3 * sqrt(S / reff)))
 
 function psis_tail!(logw, logu, M=length(logw), improved=false)
     T = eltype(logw)

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -13,7 +13,7 @@ include("utils.jl")
 include("generalized_pareto.jl")
 
 """
-    psis(log_ratios, reff=1.0; kwargs...) -> (log_weights, k)
+    psis(log_ratios, reff = 1.0; kwargs...) -> (log_weights, k)
 
 Compute Pareto smoothed importance sampling (PSIS) log weights [^VehtariSimpson2021].
 
@@ -30,9 +30,8 @@ See [`psis!`](@ref) for a version that smoothes the ratios in-place.
         multiple chains, e.g. as might be generated with Markov chain Monte Carlo.
 
   - `reff::Union{Real,AbstractVector}`: the ratio(s) of effective sample size of
-    `log_ratios` and the actual sample size, used to account for autocorrelation, e.g. due
-    to Markov chain Monte Carlo. If the ratios are known to be uncorrelated, then provide
-    `reff=ones(nparams)`.
+    `log_ratios` and the actual sample size `reff = ess/(ndraws * nchains)`, used to account
+    for autocorrelation, e.g. due to Markov chain Monte Carlo.
 
 # Keywords
 
@@ -89,7 +88,7 @@ function psis(logr, reff=1; kwargs...)
 end
 
 """
-    psis!(args[, reff=1.0]; kwargs...)
+    psis!(args, reff = 1.0; kwargs...)
 
 In-place compute Pareto smoothed importance sampling (PSIS) log weights.
 

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -13,7 +13,7 @@ include("utils.jl")
 include("generalized_pareto.jl")
 
 """
-    psis(log_ratios, r_eff; kwargs...) -> (log_weights, k)
+    psis(log_ratios, reff=1.0; kwargs...) -> (log_weights, k)
 
 Compute Pareto smoothed importance sampling (PSIS) log weights [^VehtariSimpson2021].
 
@@ -29,9 +29,10 @@ See [`psis!`](@ref) for a version that smoothes the ratios in-place.
       + `(nparams, ndraws, nchains)`: an array of draws for multiple parameters from
         multiple chains, e.g. as might be generated with Markov chain Monte Carlo.
 
-  - `r_eff`: the ratio of effective sample size of `log_ratios` and the actual sample size,
-    used to account for autocorrelation, e.g. due to Markov chain Monte Carlo. If the ratios
-    are known to be uncorrelated, then provide `r_eff=ones(nparams)`.
+  - `reff::Union{Real,AbstractVector}`: the ratio(s) of effective sample size of
+    `log_ratios` and the actual sample size, used to account for autocorrelation, e.g. due
+    to Markov chain Monte Carlo. If the ratios are known to be uncorrelated, then provide
+    `reff=ones(nparams)`.
 
 # Keywords
 


### PR DESCRIPTION
Fixes #9 by making `reff` an optional argument, defaulting to 1.