### PR TITLE
Sort only upper tail waits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/core.jl
+++ b/src/core.jl
@@ -170,8 +170,6 @@ While `psis` computes smoothed log weights out-of-place, `psis!` smooths them in
 
 # Keywords
 
-  - `sorted=issorted(vec(log_ratios))`: whether `log_ratios` are already sorted. Only
-    accepted if `nparams==1`.
   - `improved=false`: If `true`, use the adaptive empirical prior of [^Zhang2010].
     If `false`, use the simpler prior of [^ZhangStephens2009], which is also used in
     [^VehtariSimpson2021].
@@ -207,7 +205,7 @@ end
 function psis!(
     logw::AbstractVector,
     reff=1;
-    sorted::Bool=issorted(logw),
+    sorted::Bool=false, # deprecated
     improved::Bool=false,
     warn::Bool=true,
 )

--- a/src/core.jl
+++ b/src/core.jl
@@ -217,11 +217,11 @@ function psis!(
             @warn "$M tail draws is insufficient to fit the generalized Pareto distribution. $MISSING_SHAPE_SUMMARY"
         return PSISResult(logw, LogExpFunctions.logsumexp(logw), reff_val, M, missing)
     end
-    perm = sorted ? collect(eachindex(logw)) : sortperm(logw)
-    icut = S - M
-    tail_range = (icut + 1):S
-    @inbounds logw_tail = @views logw[perm[tail_range]]
-    @inbounds logu = logw[perm[icut]]
+    perm = partialsortperm(logw, (S - M):S)
+    cutoff_ind = perm[1]
+    tail_inds = @view perm[2:M + 1]
+    logu = logw[cutoff_ind]
+    logw_tail = @views logw[tail_inds]
     _, tail_dist = psis_tail!(logw_tail, logu, M, improved)
     warn && check_pareto_shape(tail_dist)
     return PSISResult(logw, LogExpFunctions.logsumexp(logw), reff_val, M, tail_dist)

--- a/src/core.jl
+++ b/src/core.jl
@@ -219,7 +219,7 @@ function psis!(
     end
     perm = partialsortperm(logw, (S - M):S)
     cutoff_ind = perm[1]
-    tail_inds = @view perm[2:M + 1]
+    tail_inds = @view perm[2:(M + 1)]
     logu = logw[cutoff_ind]
     logw_tail = @views logw[tail_inds]
     _, tail_dist = psis_tail!(logw_tail, logu, M, improved)


### PR DESCRIPTION
Fixes #20.

Benchmarks:

```julia
julia> using PSIS

julia> x1 = randn(1_000);

julia> x2 = randn(100, 1_000, 4);
```

Before this PR:
```julia
julia> @btime $psis($x);
  89.436 μs (7 allocations: 16.75 KiB)

julia> @btime $psis($x2);
  16.521 ms (1144 allocations: 6.24 MiB)
```

After this PR:
```julia
julia> @btime $psis($x);
  71.606 μs (10 allocations: 16.86 KiB)

julia> @btime $psis($x2);
  7.827 ms (1444 allocations: 6.25 MiB)
```