### PR TITLE
Warn for nonfinite tail draws

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/core.jl
+++ b/src/core.jl
@@ -8,7 +8,6 @@ const SHAPE_DIAGNOSTIC_CATEGORIES = (
 )
 const BAD_SHAPE_SUMMARY = "Resulting importance sampling estimates are likely to be unstable."
 const VERY_BAD_SHAPE_SUMMARY = "Corresponding importance sampling estimates are likely to be unstable and are unlikely to converge with additional samples."
-const MISSING_SHAPE_SUMMARY = "Total number of draws should in general exceed 25."
 
 """
     PSISResult
@@ -216,7 +215,7 @@ function psis!(
     M = tail_length(reff_val, S)
     if M < 5
         warn &&
-            @warn "$M tail draws is insufficient to fit the generalized Pareto distribution. $MISSING_SHAPE_SUMMARY"
+            @warn "$M tail draws is insufficient to fit the generalized Pareto distribution. Total number of draws should in general exceed 25."
         return PSISResult(logw, LogExpFunctions.logsumexp(logw), reff_val, M, missing)
     end
     perm = partialsortperm(logw, (S - M):S)
@@ -278,7 +277,7 @@ function check_pareto_shape(
         @warn "$ngt1 parameters had Pareto shape values k > 1. $VERY_BAD_SHAPE_SUMMARY"
     end
     if nmissing > 0
-        @warn "$nmissing parameters had insufficient tail draws to fit the generalized Pareto distribution. $MISSING_SHAPE_SUMMARY"
+        @warn "For $nmissing parameters, the generalized Pareto distribution could not be fit to the tail draws. Total number of draws should in general exceed 25, and the tail draws must be finite."
     end
     return nothing
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -223,6 +223,11 @@ function psis!(
     tail_inds = @view perm[2:(M + 1)]
     logu = logw[cutoff_ind]
     logw_tail = @views logw[tail_inds]
+    if !all(isfinite, logw_tail)
+        warn &&
+            @warn "Tail contains non-finite values. Generalized Pareto distribution cannot be reliably fit."
+        return PSISResult(logw, LogExpFunctions.logsumexp(logw), reff_val, M, missing)
+    end
     _, tail_dist = psis_tail!(logw_tail, logu, M, improved)
     warn && check_pareto_shape(tail_dist)
     return PSISResult(logw, LogExpFunctions.logsumexp(logw), reff_val, M, tail_dist)


### PR DESCRIPTION
Fitting is not attempted if the tail contains non-finite draws (for `Inf` and `NaN`, the fit cannot be computed. For `-Inf`, the degree of smoothing is much greater, and once more than 1/4 of the tail is `-Inf`, the fit would fail anyways). Instead a warning is returned.

Note that for tails with few `-Inf`, this is a breaking change.

Fixes #30 