### PR TITLE
Remove Distributions as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
 version = "0.4.0"
 
 [deps]
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
@@ -12,13 +11,10 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Distributions = "0.21.1, 0.22, 0.23, 0.24, 0.25"
 LogExpFunctions = "0.2.0, 0.3"
 PrettyTables = "1"
 RecipesBase = "1"
 Requires = "1"
-StatsBase = "0.32, 0.33"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -25,6 +25,10 @@ function __init__()
         using .Makie
         include("recipes/makie.jl")
     end
+    Requires.@require Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f" begin
+        using .Distributions: Distributions
+        include("distributions.jl")
+    end
 end
 
 end

--- a/src/PSIS.jl
+++ b/src/PSIS.jl
@@ -1,13 +1,11 @@
 module PSIS
 
-using Distributions: Distributions
 using LogExpFunctions: LogExpFunctions
 using PrettyTables: PrettyTables
 using Printf: @sprintf
 using RecipesBase: RecipesBase
 using Requires: Requires
 using Statistics: Statistics
-using StatsBase: StatsBase
 
 export PSISResult
 export psis, psis!, ess_is

--- a/src/core.jl
+++ b/src/core.jl
@@ -101,11 +101,11 @@ function pareto_shape_summary(r::PSISResult; kwargs...)
     return _print_pareto_shape_summary(stdout, r; kwargs...)
 end
 function _print_pareto_shape_summary(io::IO, r::PSISResult; kwargs...)
-    ξ = as_array(pareto_shape(r))
+    k = as_array(pareto_shape(r))
     ess = as_array(ess_is(r))
     npoints = r.nparams
     rows = map(SHAPE_DIAGNOSTIC_CATEGORIES) do (range, desc, cond)
-        inds = findall(cond, ξ)
+        inds = findall(cond, k)
         count = length(inds)
         perc = 100 * count / npoints
         ess_min = if count == 0 || desc == "too few draws"

--- a/src/core.jl
+++ b/src/core.jl
@@ -142,9 +142,7 @@ function _print_pareto_shape_summary(io::IO, r::PSISResult; kwargs...)
 end
 
 function _promote_result_type(::Type{PSISResult{T,W,N,R,L,D}}) where {T,W,N,R,L,D}
-    return PSISResult{
-        T,W,N,R,L,D2
-    } where {D2<:Union{D,Missing,Distributions.GeneralizedPareto{T}}}
+    return PSISResult{T,W,N,R,L,D2} where {D2<:Union{D,Missing,GeneralizedPareto{T}}}
 end
 
 """
@@ -255,12 +253,12 @@ function psis!(logw::AbstractArray, reff=1; warn::Bool=true, kwargs...)
 end
 
 pareto_shape(::Missing) = missing
-pareto_shape(dist::Distributions.GeneralizedPareto) = Distributions.shape(dist)
+pareto_shape(dist::GeneralizedPareto) = dist.k
 pareto_shape(r::PSISResult) = pareto_shape(getfield(r, :tail_dist))
 pareto_shape(dists) = map(pareto_shape, dists)
 
 check_pareto_shape(result::PSISResult) = check_pareto_shape(result.tail_dist)
-function check_pareto_shape(dist::Distributions.GeneralizedPareto)
+function check_pareto_shape(dist::GeneralizedPareto)
     k = pareto_shape(dist)
     if k > 1
         @warn "Pareto shape k = $(@sprintf("%.2g", k)) > 1. $VERY_BAD_SHAPE_SUMMARY"
@@ -269,9 +267,7 @@ function check_pareto_shape(dist::Distributions.GeneralizedPareto)
     end
     return nothing
 end
-function check_pareto_shape(
-    dists::AbstractVector{<:Union{Missing,Distributions.GeneralizedPareto}}
-)
+function check_pareto_shape(dists::AbstractVector{<:Union{Missing,GeneralizedPareto}})
     nmissing = count(ismissing, dists)
     ngt07 = count(x -> !(ismissing(x)) && pareto_shape(x) > 0.7, dists)
     ngt1 = iszero(ngt07) ? ngt07 : count(x -> !(ismissing(x)) && pareto_shape(x) > 1, dists)
@@ -296,17 +292,15 @@ function psis_tail!(logw, logμ, M=length(logw), improved=false)
     # equivalent to scaling the weights to have a maximum of 1.
     μ_scaled = exp(logμ - logw_max)
     w = (logw .= exp.(logw .- logw_max))
-    tail_dist_scaled = StatsBase.fit(
-        GeneralizedParetoKnownMu(μ_scaled), w; sorted=true, improved=improved
-    )
+    tail_dist_scaled = fit_gpd(w; sorted=true, improved=improved, μ=μ_scaled)
     tail_dist_adjusted = prior_adjust_shape(tail_dist_scaled, M)
     # undo the scaling
-    ξ = Distributions.shape(tail_dist_adjusted)
-    if isfinite(ξ)
+    k = tail_dist_adjusted.k
+    if isfinite(k)
         p = uniform_probabilities(T, M)
         @inbounds for i in eachindex(logw, p)
             # undo scaling in the log-weights
-            logw[i] = min(log(_quantile(tail_dist_adjusted, p[i])), 0) + logw_max
+            logw[i] = min(log(quantile(tail_dist_adjusted, p[i])), 0) + logw_max
         end
     end
     return logw, tail_dist_adjusted

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,0 +1,10 @@
+function Base.convert(
+    ::Type{Distributions.GeneralizedPareto{T}}, d::GeneralizedPareto{S}
+) where {T<:Real,S<:Real}
+    return Distributions.GeneralizedPareto{T}(T(d.μ), T(d.σ), T(d.k))
+end
+function Base.convert(
+    ::Type{Distributions.GeneralizedPareto}, d::GeneralizedPareto{T}
+) where {T<:Real}
+    return convert(Distributions.GeneralizedPareto{T}, d)
+end

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -34,39 +34,10 @@ end
 # MLE
 #
 
-"""
-    GeneralizedParetoKnownMuTheta(μ, θ)
-
-Represents a [`GeneralizedPareto`](@ref) where ``\\mu`` and ``\\theta=\\frac{\\xi}{\\sigma}`` are known.
-"""
-struct GeneralizedParetoKnownMuTheta{T} <: Distributions.IncompleteDistribution
-    μ::T
-    θ::T
-end
-GeneralizedParetoKnownMuTheta(μ, θ) = GeneralizedParetoKnownMuTheta(Base.promote(μ, θ)...)
-
-struct GeneralizedParetoKnownMuThetaStats{T} <: Distributions.SufficientStats
-    μ::T  # known mean
-    θ::T  # known theta
-    ξ::T  # known shape
-end
-
-function Distributions.suffstats(d::GeneralizedParetoKnownMuTheta, x::AbstractArray)
-    μ = d.μ
-    θ = d.θ
-    ξ = Statistics.mean(xi -> log1p(θ * (xi - μ)), x) # mle estimate of ξ
-    return GeneralizedParetoKnownMuThetaStats(μ, θ, ξ)
-end
-
-function Distributions.fit_mle(g::GeneralizedParetoKnownMuTheta, x::AbstractArray)
-    ss = Distributions.suffstats(g, x)
-    return Distributions.fit_mle(g, ss)
-end
-function Distributions.fit_mle(
-    d::GeneralizedParetoKnownMuTheta, ss::GeneralizedParetoKnownMuThetaStats
-)
-    ξ = ss.ξ
-    return Distributions.GeneralizedPareto(d.μ, ξ / d.θ, ξ)
+function _fit_gpd_mle_given_mu_theta(x::AbstractArray, μ, θ)
+    k = Statistics.mean(xi -> log1p(θ * (xi - μ)), x) # mle estimate of k
+    σ = k / θ
+    return GeneralizedPareto(μ, σ, k)
 end
 
 #

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -23,11 +23,11 @@ struct GeneralizedPareto{T}
 end
 GeneralizedPareto(μ, σ, k) = GeneralizedPareto(Base.promote(μ, σ, k)...)
 
-function _quantile(d::Distributions.GeneralizedPareto{T}, p::Real) where {T<:Real}
-    (μ, σ, ξ) = Distributions.params(d)
+function quantile(d::GeneralizedPareto{T}, p::Real) where {T<:Real}
     nlog1pp = -log1p(-p * one(T))
-    z = abs(ξ) < eps() ? nlog1pp : expm1(ξ * nlog1pp) / ξ
-    return muladd(σ, z, μ)
+    k = d.k
+    z = abs(k) < eps() ? nlog1pp : expm1(k * nlog1pp) / k
+    return muladd(d.σ, z, d.μ)
 end
 
 #

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -18,6 +18,7 @@ Construct the generalized Pareto distribution (GPD) with location parameter ``μ
 parameter ``σ`` and shape parameter ``k``.
 
 !!! note
+    
     The shape parameter ``k`` is equivalent to the commonly used shape parameter ``ξ``.
     This is the same parameterization used by [^VehtariSimpson2021] and is related to that
     used by [^ZhangStephens2009] as ``k \\mapsto -k``.

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -1,3 +1,26 @@
+# Note: These internal functions are here to avoid a dependency on Distributions.jl,
+# which currently does not implement GPD fitting anyways. They are not methods of
+# functions in Statistics/StatsBase
+
+"""
+    GeneralizedPareto{T<:Real}
+
+The (zero-centered) generalized Pareto distribution.
+
+# Constructor
+
+    GeneralizedPareto(σ, k)
+
+Construct the generalized Pareto distribution (GPD) with scale parameter ``σ`` and shape
+parameter ``k``. Note that this ``k`` is equal to the commonly used shape parameter ``ξ``.
+This is the same parameterization used by [^VehtariSimpson2021] and is related to that used
+by [^ZhangStephens2009] as ``k \\mapsto -k``.
+"""
+struct GeneralizedPareto{T}
+    σ::T
+    k::T
+end
+GeneralizedPareto(σ, k) = GeneralizedPareto(Base.promote(σ, k)...)
 
 function _quantile(d::Distributions.GeneralizedPareto{T}, p::Real) where {T<:Real}
     (μ, σ, ξ) = Distributions.params(d)

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -5,22 +5,23 @@
 """
     GeneralizedPareto{T<:Real}
 
-The (zero-centered) generalized Pareto distribution.
+The generalized Pareto distribution.
 
 # Constructor
 
-    GeneralizedPareto(σ, k)
+    GeneralizedPareto(μ, σ, k)
 
-Construct the generalized Pareto distribution (GPD) with scale parameter ``σ`` and shape
-parameter ``k``. Note that this ``k`` is equal to the commonly used shape parameter ``ξ``.
-This is the same parameterization used by [^VehtariSimpson2021] and is related to that used
-by [^ZhangStephens2009] as ``k \\mapsto -k``.
+Construct the generalized Pareto distribution (GPD) with location parameter ``μ``, scale
+parameter ``σ`` and shape parameter ``k``. Note that this ``k`` is equal to the commonly
+used shape parameter ``ξ``. This is the same parameterization used by [^VehtariSimpson2021]
+and is related to that used by [^ZhangStephens2009] as ``k \\mapsto -k``.
 """
 struct GeneralizedPareto{T}
+    μ::T
     σ::T
     k::T
 end
-GeneralizedPareto(σ, k) = GeneralizedPareto(Base.promote(σ, k)...)
+GeneralizedPareto(μ, σ, k) = GeneralizedPareto(Base.promote(μ, σ, k)...)
 
 function _quantile(d::Distributions.GeneralizedPareto{T}, p::Real) where {T<:Real}
     (μ, σ, ξ) = Distributions.params(d)

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -7,14 +7,20 @@
 
 The generalized Pareto distribution.
 
+This is equivalent to `Distributions.GeneralizedPareto` and can be converted to one with
+`convert(Distributions.GeneralizedPareto, d)`.
+
 # Constructor
 
     GeneralizedPareto(μ, σ, k)
 
 Construct the generalized Pareto distribution (GPD) with location parameter ``μ``, scale
-parameter ``σ`` and shape parameter ``k``. Note that this ``k`` is equal to the commonly
-used shape parameter ``ξ``. This is the same parameterization used by [^VehtariSimpson2021]
-and is related to that used by [^ZhangStephens2009] as ``k \\mapsto -k``.
+parameter ``σ`` and shape parameter ``k``.
+
+!!! note
+    The shape parameter ``k`` is equivalent to the commonly used shape parameter ``ξ``.
+    This is the same parameterization used by [^VehtariSimpson2021] and is related to that
+    used by [^ZhangStephens2009] as ``k \\mapsto -k``.
 """
 struct GeneralizedPareto{T}
     μ::T

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -45,18 +45,9 @@ end
 #
 
 """
-    GeneralizedParetoKnownMu(μ)
+    fit_gpd(x; μ=0, kwargs...)
 
-Represents a [`GeneralizedPareto`](@ref) where ``\\mu`` is known.
-"""
-struct GeneralizedParetoKnownMu{T} <: Distributions.IncompleteDistribution
-    μ::T
-end
-
-"""
-    fit(g::GeneralizedParetoKnownMu, x; kwargs...)
-
-Fit a [`GeneralizedPareto`](@ref) with known location `μ` to the data `x`.
+Fit a [`GeneralizedPareto`](@ref) with location `μ` to the data `x`.
 
 The fit is performed using the Empirical Bayes method of [^ZhangStephens2009][^Zhang2010].
 
@@ -77,9 +68,7 @@ The fit is performed using the Empirical Bayes method of [^ZhangStephens2009][^Z
     Technometrics, 52:3, 335-339,
     DOI: [10.1198/TECH.2010.09206](https://doi.org/10.1198/TECH.2010.09206)
 """
-function StatsBase.fit(g::GeneralizedParetoKnownMu, x::AbstractArray; kwargs...)
-    return fit_empiricalbayes(g, x; kwargs...)
-end
+fit_gpd(x::AbstractArray; kwargs...) = fit_gpd_empiricalbayes(x; kwargs...)
 
 # Note: our ξ is ZhangStephens2009's -k, and our θ is ZhangStephens2009's -θ
 

--- a/src/recipes/plots.jl
+++ b/src/recipes/plots.jl
@@ -28,15 +28,15 @@ RecipesBase.@recipe function f(config::ParetoShapePlotConfig; showlines=false)
     ylabel --> "Pareto shape"
     seriestype --> :scatter
     arg = first(config.args)
-    ξ = as_array(missing_to_nan(arg isa PSISResult ? pareto_shape(arg) : arg))
-    return (ξ,)
+    k = as_array(missing_to_nan(arg isa PSISResult ? pareto_shape(arg) : arg))
+    return (k,)
 end
 
 # plot PSISResult using paretoshapeplot if seriestype not specified
 RecipesBase.@recipe function f(result::PSISResult)
     if haskey(plotattributes, :seriestype)
-        ξ = as_array(missing_to_nan(pareto_shape(result)))
-        return (ξ,)
+        k = as_array(missing_to_nan(pareto_shape(result)))
+        return (k,)
     else
         return ParetoShapePlotConfig((result,))
     end

--- a/test/ess.jl
+++ b/test/ess.jl
@@ -17,10 +17,10 @@ using Test
 
     logw = randn(100)
     logw_norm = logsumexp(logw)
-    result = PSISResult(logw, logw_norm, 1.5, 20, GeneralizedPareto(0.0, 1.0, 0.6))
+    result = PSISResult(logw, logw_norm, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.6))
     @test ess_is(result) ≈ ess_is(exp.(logw .- logw_norm); reff=1.5)
 
-    result = PSISResult(logw, logw_norm, 1.5, 20, GeneralizedPareto(0.0, 1.0, 0.71))
+    result = PSISResult(logw, logw_norm, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.71))
     @test ismissing(ess_is(result))
     @test ess_is(result; bad_shape_missing=false) ≈
         ess_is(exp.(logw .- logw_norm); reff=1.5)
@@ -28,7 +28,9 @@ using Test
     logw = randn(3, 100, 4)
     logw_norm = dropdims(logsumexp(logw; dims=(2, 3)); dims=(2, 3))
     tail_dists = [
-        GeneralizedPareto(0.0, 1.0, 0.69), GeneralizedPareto(0.0, 1.0, 0.71), missing
+        PSIS.GeneralizedPareto(0.0, 1.0, 0.69),
+        PSIS.GeneralizedPareto(0.0, 1.0, 0.71),
+        missing,
     ]
     reff = [1.5, 0.8, 1.0]
     result = PSISResult(logw, logw_norm, reff, [20, 20, 20], tail_dists)

--- a/test/generalized_pareto.jl
+++ b/test/generalized_pareto.jl
@@ -26,4 +26,12 @@ using Test
             @test dhat.k == -1
         end
     end
+    @testset "convert to Distributions type" begin
+        d = PSIS.GeneralizedPareto(1.0, 2.0, 3.0)
+        @test @inferred(convert(Distributions.GeneralizedPareto, d)) ===
+            Distributions.GeneralizedPareto(1.0, 2.0, 3.0)
+        d = PSIS.GeneralizedPareto(0.0, 0.0, -1.0)
+        @test @inferred(convert(Distributions.GeneralizedPareto{Float32}, d)) ===
+            Distributions.GeneralizedPareto{Float32}(0.0f0, 0.0f0, -1.0f0)
+    end
 end

--- a/test/generalized_pareto.jl
+++ b/test/generalized_pareto.jl
@@ -4,28 +4,26 @@ using Random
 using Test
 
 @testset "Generalized Pareto distribution" begin
-    @testset "fit" begin
+    @testset "fit_gpd" begin
         @testset for μ in (-1, 5),
             σ in (0.5, 1.0, 2.0),
-            ξ in (-1.0, 0.0, 0.3, 1.0, 2.0),
+            k in (-1.0, 0.0, 0.3, 1.0, 2.0),
             improved in (true, false)
 
-            d = GeneralizedPareto(μ, σ, ξ)
+            d = Distributions.GeneralizedPareto(μ, σ, k)
             rng = MersenneTwister(42)
             x = rand(rng, d, 200_000)
-            dhat = fit(
-                PSIS.GeneralizedParetoKnownMu(μ), x; min_points=80, improved=improved
-            )
+            dhat = PSIS.fit_gpd(x; μ=μ, min_points=80, improved=improved)
             @test dhat.μ == μ
             @test dhat.σ ≈ σ atol = 0.01
-            @test dhat.ξ ≈ ξ atol = 0.01
+            @test dhat.k ≈ k atol = 0.01
         end
         @testset "nearly uniform" begin
             x = ones(200_000)
-            dhat = fit(PSIS.GeneralizedParetoKnownMu(1.0), x; min_points=80)
+            dhat = PSIS.fit_gpd(x; μ=1.0, min_points=80)
             @test dhat.μ == 1.0
-            @test dhat.σ ≈ eps(0.0)
-            @test dhat.ξ ≈ -1
+            @test dhat.σ == 0.0
+            @test dhat.k == -1
         end
     end
 end


### PR DESCRIPTION
In #4, we switched to using Distributions types internally for fitting the GPD distribution, with the hopes of upstreaming to Distributions.jl. However, as noted in #33, Distributions is our heaviest dependency, and we don't even use its functionality. This PR reintroduces our own `GeneralizedPareto` type. It also replaces internal uses of `ξ` with `k` for consistency with the PSIS paper and docstrings.

On master:
```julia
julia> @time using PSIS
  0.651524 seconds (1.97 M allocations: 125.510 MiB, 14.28% compilation time)
```

This PR:
```julia
julia> @time using PSIS
  0.180238 seconds (431.68 k allocations: 29.864 MiB, 9.45% compilation time)
```