### PR TITLE
Change dimension order to (ndraws, nchains, nparams)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/core.jl
+++ b/src/core.jl
@@ -94,7 +94,7 @@ function Base.show(io::IO, ::MIME"text/plain", r::PSISResult)
     npoints = r.nparams
     nchains = r.nchains
     println(
-        io, "PSISResult with $npoints parameters, $(r.ndraws) draws, and $nchains chains"
+        io, "PSISResult with $(r.ndraws) draws, $nchains chains, and $npoints parameters"
     )
     return _print_pareto_shape_summary(io, r; newline_at_end=false)
 end

--- a/src/ess.jl
+++ b/src/ess.jl
@@ -28,10 +28,10 @@ function ess_is(r::PSISResult; bad_shape_missing::Bool=true)
 end
 function ess_is(weights; reff=1)
     dims = sample_dims(weights)
-    neff = reff ./ sum(abs2, weights; dims=dims)
-    weights isa AbstractVector && return neff[1]
+    neff = broadcast_last_dims(/, reff, sum(abs2, weights; dims=dims))
     return dropdims(neff; dims=dims)
 end
+ess_is(weights::AbstractVector; reff::Real=1) = reff / sum(abs2, weights)
 
 function _apply_missing(neff, dist; bad_shape_missing)
     return bad_shape_missing && pareto_shape(dist) > 0.7 ? missing : neff

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,3 +31,28 @@ function sample_dims(x::AbstractArray)
     return filter(!=(d), ntuple(identity, ndims(x)))
 end
 sample_dims(::AbstractVector) = Colon()
+
+"""
+    broadcast_last_dims(f, x, y)
+
+Compute `f.(x, y)` but where `y` shares the last dimensions of `x` instead of the first.
+
+This function adds leading singleton dimensions to `y` until it has the same number of
+dimensions as `x`.
+
+The function tries to keep the final array type as close as possible to the input type.
+"""
+function broadcast_last_dims(f, x, y)
+    (x isa Number || y isa Number || ndims(x) == ndims(y)) && return f.(x, y)
+    if ndims(x) > ndims(y)
+        yreshape = reshape(y, ntuple(one, ndims(x) - ndims(y))..., size(y)...)
+        z = f.(x, yreshape)
+        zdim = similar(x, eltype(z))
+    else
+        xreshape = reshape(x, ntuple(one, ndims(y) - ndims(x))..., size(x)...)
+        z = f.(xreshape, y)
+        zdim = similar(y, eltype(z))
+    end
+    copyto!(zdim, z)
+    return zdim
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,16 +13,16 @@ missing_to_nan(x) = x
 # dimension corresponding to parameters
 function param_dim(x)
     @assert ndims(x) > 1
-    return 1
+    return ndims(x)
 end
 
 # view of first draw from first chain (i.e. vector of parameters)
 function first_draw(x::AbstractArray)
-    dims = Base.setindex(ntuple(one, ndims(x)), :, param_dim(x))
+    dims = Base.setindex(map(first, axes(x)), :, param_dim(x))
     return view(x, dims...)
 end
 
-# view of all draws 
+# view of all draws
 param_draws(x::AbstractArray, i::Int) = selectdim(x, param_dim(x), i)
 
 # dimensions corresponding to draws and chains

--- a/test/core.jl
+++ b/test/core.jl
@@ -42,7 +42,7 @@ using AxisArrays: AxisArrays
 
         @testset "show" begin
             @test sprint(show, "text/plain", result) == """
-                PSISResult with 1 parameters, 500 draws, and 1 chains
+                PSISResult with 500 draws, 1 chains, and 1 parameters
                 Pareto shape (k) diagnostic values:
                                     Count       Min. ESS
                  (-Inf, 0.5]  good  1 (100.0%)  $(floor(Int, result.ess))"""
@@ -81,7 +81,7 @@ using AxisArrays: AxisArrays
             reff = [100; ones(29)]
             result = psis(log_ratios, reff)
             @test sprint(show, "text/plain", result) == """
-                PSISResult with 30 parameters, 100 draws, and 1 chains
+                PSISResult with 100 draws, 1 chains, and 30 parameters
                 Pareto shape (k) diagnostic values:
                                         Count       Min. ESS
                  (-Inf, 0.5]  good       4 (13.3%)  95

--- a/test/core.jl
+++ b/test/core.jl
@@ -50,8 +50,8 @@ using AxisArrays: AxisArrays
     end
 
     @testset "array log-weights" begin
-        log_weights = randn(3, 500, 4)
-        log_weights_norm = dropdims(logsumexp(log_weights; dims=(2, 3)); dims=(2, 3))
+        log_weights = randn(500, 4, 3)
+        log_weights_norm = dropdims(logsumexp(log_weights; dims=(1, 2)); dims=(1, 2))
         tail_length = [1600, 1601, 1602]
         reff = [0.8, 0.9, 1.1]
         tail_dist = [
@@ -63,7 +63,7 @@ using AxisArrays: AxisArrays
         @test result isa PSISResult{Float64}
         @test result.log_weights == log_weights
         @test result.log_weights_norm == log_weights_norm
-        @test result.weights ≈ softmax(log_weights; dims=(2, 3))
+        @test result.weights ≈ softmax(log_weights; dims=(1, 2))
         @test result.reff == reff
         @test result.nparams == 3
         @test result.ndraws == 500
@@ -76,7 +76,7 @@ using AxisArrays: AxisArrays
             proposal = Normal()
             target = TDist(7)
             rng = MersenneTwister(42)
-            x = rand(rng, proposal, 30, 100)
+            x = rand(rng, proposal, 100, 30)
             log_ratios = logpdf.(target, x) .- logpdf.(proposal, x)
             reff = [100; ones(29)]
             result = psis(log_ratios, reff)
@@ -84,10 +84,10 @@ using AxisArrays: AxisArrays
                 PSISResult with 30 parameters, 100 draws, and 1 chains
                 Pareto shape (k) diagnostic values:
                                         Count       Min. ESS
-                 (-Inf, 0.5]  good       1 (3.3%)   95
-                  (0.5, 0.7]  okay       3 (10.0%)  97
-                    (0.7, 1]  bad        5 (16.7%)  ——
-                    (1, Inf)  very bad  20 (66.7%)  ——
+                 (-Inf, 0.5]  good       4 (13.3%)  95
+                  (0.5, 0.7]  okay       2 (6.7%)   97
+                    (0.7, 1]  bad        4 (13.3%)  ——
+                    (1, Inf)  very bad  19 (63.3%)  ——
                           ——  missing    1 (3.3%)   ——"""
         end
     end
@@ -108,8 +108,8 @@ end
         ]
             proposal = Exponential(θ)
             k_exp = 1 - θ
-            for sz in ((100_000,), (5, 100_000), (5, 100_000, 4))
-                dims = length(sz) == 1 ? Colon() : 2:length(sz)
+            for sz in ((100_000,), (100_000, 5), (100_000, 4, 5))
+                dims = length(sz) == 1 ? Colon() : 1:(length(sz) - 1)
                 rng = MersenneTwister(42)
                 x = rand(rng, proposal, sz)
                 logr = logpdf.(target, x) .- logpdf.(proposal, x)
@@ -261,6 +261,7 @@ end
         sz = (5, 1_000, 4)
         x = rand(rng, proposal, sz)
         logr = logpdf.(target, x) .- logpdf.(proposal, x)
+        logr = permutedims(logr, (2, 3, 1))
         @testset for r_eff in (0.7, 1.2), improved in (true, false)
             r_effs = fill(r_eff, sz[1])
             result = psis(logr, r_effs; improved=improved)
@@ -275,8 +276,11 @@ end
                 Dict("log_weights" => logw, "pareto_shape" => result.pareto_shape),
                 by =
                     (ref, x) ->
-                        isapprox(ref["log_weights"], x["log_weights"]; rtol=1e-6) &&
-                            isapprox(ref["pareto_shape"], x["pareto_shape"]; rtol=1e-6),
+                        isapprox(
+                            permutedims(ref["log_weights"], (2, 3, 1)),
+                            x["log_weights"];
+                            rtol=1e-6,
+                        ) && isapprox(ref["pareto_shape"], x["pareto_shape"]; rtol=1e-6),
             )
         end
     end
@@ -290,14 +294,14 @@ end
         param_names = [Symbol("x[$i]") for i in 1:10]
         iter_names = 101:200
         chain_names = 1:4
-        x = randn(length(param_names), length(iter_names), length(chain_names))
+        x = randn(length(iter_names), length(chain_names), length(param_names))
 
         @testset "AxisArrays" begin
             logr = AxisArrays.AxisArray(
                 x,
-                AxisArrays.Axis{:param}(param_names),
                 AxisArrays.Axis{:iter}(iter_names),
                 AxisArrays.Axis{:chain}(chain_names),
+                AxisArrays.Axis{:param}(param_names),
             )
             result = psis(logr)
             @test result.log_weights isa AxisArrays.AxisArray
@@ -305,7 +309,7 @@ end
             for k in (:pareto_shape, :tail_length, :tail_dist, :reff, :log_weights_norm)
                 prop = getproperty(result, k)
                 @test prop isa AxisArrays.AxisArray
-                @test AxisArrays.axes(prop) == (AxisArrays.axes(logr, 1),)
+                @test AxisArrays.axes(prop) == (AxisArrays.axes(logr, 3),)
             end
         end
     end

--- a/test/ess.jl
+++ b/test/ess.jl
@@ -25,8 +25,8 @@ using Test
     @test ess_is(result; bad_shape_missing=false) ≈
         ess_is(exp.(logw .- logw_norm); reff=1.5)
 
-    logw = randn(3, 100, 4)
-    logw_norm = dropdims(logsumexp(logw; dims=(2, 3)); dims=(2, 3))
+    logw = randn(100, 4, 3)
+    logw_norm = dropdims(logsumexp(logw; dims=(1, 2)); dims=(1, 2))
     tail_dists = [
         PSIS.GeneralizedPareto(0.0, 1.0, 0.69),
         PSIS.GeneralizedPareto(0.0, 1.0, 0.71),

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "PSISPlots" begin
     @testset "$f" for f in (PSISPlots.paretoshapeplot, PSISPlots.paretoshapeplot!),
-        sz in (100, (10, 100))
+        sz in (100, (100, 10))
 
         result = psis(randn(sz...))
 
@@ -35,7 +35,7 @@ using Test
     end
 
     @testset "plot(::PSISResult)" begin
-        result = psis(randn(10, 100))
+        result = psis(randn(100, 10))
         for showlines in (true, false)
             plt = PSISPlots.paretoshapeplot(result; showlines=showlines)
             plt2 = plot(result; showlines=showlines)
@@ -49,7 +49,7 @@ using Test
     end
 
     @testset "plot(::PSISResult; seriestype=:path)" begin
-        result = psis(randn(10, 100))
+        result = psis(randn(100, 10))
         plt = plot(result; seriestype=:path)
         @test length(plt.series_list) == 1
         @test plt[1][1][:x] == eachindex(result.pareto_shape)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -34,4 +34,21 @@ using Test
         x = randn(10, 100, 4)
         @test PSIS.sample_dims(x) === (2, 3)
     end
+
+    @testset "broadcast_last_dims" begin
+        adim = AxisArrays.Axis{:a}([Symbol("a[$i]") for i in 1:2])
+        bdim = AxisArrays.Axis{:b}([Symbol("b[$i]") for i in 1:10])
+        x = AxisArrays.AxisArray(randn(2, 10), adim, bdim)
+        y = AxisArrays.AxisArray(randn(10), bdim)
+        @test @inferred(PSIS.broadcast_last_dims(/, x[1, :], y)) == x[1, :] ./ y
+        @test @inferred(PSIS.broadcast_last_dims(/, x, y)) == x ./ reshape(y, 1, :)
+        @test @inferred(PSIS.broadcast_last_dims(/, y, x)) == reshape(y, 1, :) ./ x
+        @test @inferred(PSIS.broadcast_last_dims(/, x, 3)) == x ./ 3
+        @test @inferred(PSIS.broadcast_last_dims(/, 4, x)) == 4 ./ x
+
+        @test PSIS.broadcast_last_dims(/, x, y) isa AxisArrays.AxisArray
+        @test AxisArrays.axes(PSIS.broadcast_last_dims(/, x, y)) == AxisArrays.axes(x)
+        @test PSIS.broadcast_last_dims(/, y, x) isa AxisArrays.AxisArray
+        @test AxisArrays.axes(PSIS.broadcast_last_dims(/, y, x)) == AxisArrays.axes(x)
+    end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,36 +3,36 @@ using Test
 
 @testset "utils" begin
     @testset "param_dim" begin
-        x = randn(10, 100)
-        @test PSIS.param_dim(x) == 1
+        x = randn(100, 10)
+        @test PSIS.param_dim(x) == 2
 
-        x = randn(10, 100, 4)
-        @test PSIS.param_dim(x) == 1
+        x = randn(100, 4, 10)
+        @test PSIS.param_dim(x) == 3
     end
 
     @testset "first_draw" begin
-        x = randn(10, 100)
-        @test PSIS.first_draw(x) === view(x, :, 1)
+        x = randn(100, 10)
+        @test PSIS.first_draw(x) === view(x, 1, :)
 
-        x = randn(10, 100, 4)
-        @test PSIS.first_draw(x) === view(x, :, 1, 1)
+        x = randn(100, 4, 10)
+        @test PSIS.first_draw(x) === view(x, 1, 1, :)
     end
 
     @testset "param_draws" begin
-        x = randn(10, 100)
-        @test PSIS.param_draws(x, 3) === view(x, 3, :)
+        x = randn(100, 10)
+        @test PSIS.param_draws(x, 3) === view(x, :, 3)
 
-        x = randn(10, 100, 4)
-        @test PSIS.param_draws(x, 5) === view(x, 5, :, :)
+        x = randn(100, 4, 10)
+        @test PSIS.param_draws(x, 5) === view(x, :, :, 5)
     end
 
     @testset "sample_dims" begin
         x = randn(100)
         @test PSIS.sample_dims(x) === Colon()
-        x = randn(10, 100)
-        @test PSIS.sample_dims(x) === (2,)
-        x = randn(10, 100, 4)
-        @test PSIS.sample_dims(x) === (2, 3)
+        x = randn(100, 10)
+        @test PSIS.sample_dims(x) === (1,)
+        x = randn(100, 4, 10)
+        @test PSIS.sample_dims(x) === (1, 2)
     end
 
     @testset "broadcast_last_dims" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,6 @@
 using PSIS
 using Test
+using AxisArrays: AxisArrays
 
 @testset "utils" begin
     @testset "param_dim" begin


### PR DESCRIPTION
This PR changes the dimension order of the inputs to `(ndraws, nchains, nparams)`. The reasons are the same as those in https://github.com/arviz-devs/InferenceObjects.jl/pull/40.