### PR TITLE
Improve support for (multi-)dimensional arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-AxisArrays = "0.4"
+DimensionalData = "0.24"
 Distributions = "0.25.81"
 JLD2 = "0.4"
 LogExpFunctions = "0.2.0, 0.3"
@@ -21,7 +21,7 @@ ReferenceTests = "0.9"
 julia = "1.6"
 
 [extras]
-AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -31,4 +31,4 @@ ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AxisArrays", "Distributions", "Logging", "JLD2", "Plots", "Random", "ReferenceTests", "Test"]
+test = ["DimensionalData", "Distributions", "Logging", "JLD2", "Plots", "Random", "ReferenceTests", "Test"]

--- a/src/core.jl
+++ b/src/core.jl
@@ -263,7 +263,9 @@ function psis!(logw::AbstractArray, reff=1; warn::Bool=true, kwargs...)
     end
 
     # combine results
-    result = PSISResult(logw, log_weights_norm, reffs, tail_lengths, tail_dists)
+    result = PSISResult(
+        logw, log_weights_norm, reffs, tail_lengths, map(identity, tail_dists)
+    )
 
     # warn for bad shape
     warn && check_pareto_shape(result)

--- a/src/ess.jl
+++ b/src/ess.jl
@@ -37,7 +37,7 @@ function _apply_missing(neff, dist; bad_shape_missing)
     return bad_shape_missing && pareto_shape(dist) > 0.7 ? missing : neff
 end
 _apply_missing(neff, ::Missing; kwargs...) = missing
-function _apply_missing(ess::AbstractVector, tail_dist::AbstractVector; kwargs...)
+function _apply_missing(ess::AbstractArray, tail_dist::AbstractArray; kwargs...)
     return map(ess, tail_dist) do essᵢ, tail_distᵢ
         return _apply_missing(essᵢ, tail_distᵢ; kwargs...)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,12 +16,6 @@ function param_dim(x)
     return ndims(x)
 end
 
-# view of first draw from first chain (i.e. vector of parameters)
-function first_draw(x::AbstractArray)
-    dims = Base.setindex(map(first, axes(x)), :, param_dim(x))
-    return view(x, dims...)
-end
-
 # view of all draws
 param_draws(x::AbstractArray, i::Int) = selectdim(x, param_dim(x), i)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,18 +11,23 @@ missing_to_nan(::Missing) = NaN
 missing_to_nan(x) = x
 
 # dimension corresponding to parameters
-function param_dim(x)
-    @assert ndims(x) > 1
-    return ndims(x)
+function param_dims(x)
+    N = ndims(x)
+    @assert N > 1
+    N == 2 && return (2,)
+    N ≥ 3 && return ntuple(i -> i + 2, N - 2)
 end
 
 # view of all draws
-param_draws(x::AbstractArray, i::Int) = selectdim(x, param_dim(x), i)
+function param_draws(x::AbstractArray, i::CartesianIndex)
+    sample_dims = ntuple(_ -> Colon(), ndims(x) - length(i))
+    return view(x, sample_dims..., i)
+end
 
 # dimensions corresponding to draws and chains
 function sample_dims(x::AbstractArray)
-    d = param_dim(x)
-    return filter(!=(d), ntuple(identity, ndims(x)))
+    d = param_dims(x)
+    return filter(∉(d), ntuple(identity, ndims(x)))
 end
 sample_dims(::AbstractVector) = Colon()
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -5,7 +5,7 @@ using ReferenceTests
 using Distributions: GeneralizedPareto, Normal, Cauchy, Exponential, TDist, logpdf
 using LogExpFunctions: logsumexp, softmax
 using Logging: SimpleLogger, with_logger
-using AxisArrays: AxisArrays
+using DimensionalData: Dimensions, DimArray
 
 @testset "PSISResult" begin
     @testset "vector log-weights" begin
@@ -280,20 +280,22 @@ end
         chain_names = 1:4
         x = randn(length(iter_names), length(chain_names), length(param_names))
 
-        @testset "AxisArrays" begin
-            logr = AxisArrays.AxisArray(
+        @testset "DimensionalData" begin
+            logr = DimArray(
                 x,
-                AxisArrays.Axis{:iter}(iter_names),
-                AxisArrays.Axis{:chain}(chain_names),
-                AxisArrays.Axis{:param}(param_names),
+                (
+                    Dimensions.Dim{:iter}(iter_names),
+                    Dimensions.Dim{:chain}(chain_names),
+                    Dimensions.Dim{:param}(param_names),
+                ),
             )
             result = psis(logr)
-            @test result.log_weights isa AxisArrays.AxisArray
-            @test AxisArrays.axes(result.log_weights) == AxisArrays.axes(logr)
+            @test result.log_weights isa DimArray
+            @test Dimensions.dims(result.log_weights) == Dimensions.dims(logr)
             for k in (:pareto_shape, :tail_length, :tail_dist, :reff, :log_weights_norm)
                 prop = getproperty(result, k)
-                @test prop isa AxisArrays.AxisArray
-                @test AxisArrays.axes(prop) == (AxisArrays.axes(logr, 3),)
+                @test prop isa DimArray
+                @test Dimensions.dims(prop) == Dimensions.dims(logr, (:param,))
             end
         end
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,14 +11,6 @@ using AxisArrays: AxisArrays
         @test PSIS.param_dim(x) == 3
     end
 
-    @testset "first_draw" begin
-        x = randn(100, 10)
-        @test PSIS.first_draw(x) === view(x, 1, :)
-
-        x = randn(100, 4, 10)
-        @test PSIS.first_draw(x) === view(x, 1, 1, :)
-    end
-
     @testset "param_draws" begin
         x = randn(100, 10)
         @test PSIS.param_draws(x, 3) === view(x, :, 3)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,6 @@
 using PSIS
 using Test
-using AxisArrays: AxisArrays
+using DimensionalData: Dimensions, DimArray
 
 @testset "utils" begin
     @testset "param_dim" begin
@@ -41,19 +41,19 @@ using AxisArrays: AxisArrays
     end
 
     @testset "broadcast_last_dims" begin
-        adim = AxisArrays.Axis{:a}([Symbol("a[$i]") for i in 1:2])
-        bdim = AxisArrays.Axis{:b}([Symbol("b[$i]") for i in 1:10])
-        x = AxisArrays.AxisArray(randn(2, 10), adim, bdim)
-        y = AxisArrays.AxisArray(randn(10), bdim)
+        adim = Dimensions.Dim{:a}([Symbol("a[$i]") for i in 1:2])
+        bdim = Dimensions.Dim{:b}([Symbol("b[$i]") for i in 1:10])
+        x = DimArray(randn(2, 10), (adim, bdim))
+        y = DimArray(randn(10), (bdim,))
         @test @inferred(PSIS.broadcast_last_dims(/, x[1, :], y)) == x[1, :] ./ y
         @test @inferred(PSIS.broadcast_last_dims(/, x, y)) == x ./ reshape(y, 1, :)
         @test @inferred(PSIS.broadcast_last_dims(/, y, x)) == reshape(y, 1, :) ./ x
         @test @inferred(PSIS.broadcast_last_dims(/, x, 3)) == x ./ 3
         @test @inferred(PSIS.broadcast_last_dims(/, 4, x)) == 4 ./ x
 
-        @test PSIS.broadcast_last_dims(/, x, y) isa AxisArrays.AxisArray
-        @test AxisArrays.axes(PSIS.broadcast_last_dims(/, x, y)) == AxisArrays.axes(x)
-        @test PSIS.broadcast_last_dims(/, y, x) isa AxisArrays.AxisArray
-        @test AxisArrays.axes(PSIS.broadcast_last_dims(/, y, x)) == AxisArrays.axes(x)
+        @test PSIS.broadcast_last_dims(/, x, y) isa DimArray
+        @test Dimensions.dims(PSIS.broadcast_last_dims(/, x, y)) == Dimensions.dims(x)
+        @test PSIS.broadcast_last_dims(/, y, x) isa DimArray
+        @test Dimensions.dims(PSIS.broadcast_last_dims(/, y, x)) == Dimensions.dims(x)
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -5,18 +5,30 @@ using AxisArrays: AxisArrays
 @testset "utils" begin
     @testset "param_dim" begin
         x = randn(100, 10)
-        @test PSIS.param_dim(x) == 2
+        @test PSIS.param_dims(x) == (2,)
 
         x = randn(100, 4, 10)
-        @test PSIS.param_dim(x) == 3
+        @test PSIS.param_dims(x) == (3,)
+
+        x = randn(100, 4, 5, 10)
+        @test PSIS.param_dims(x) == (3, 4)
+
+        x = randn(100, 4, 5, 6, 10)
+        @test PSIS.param_dims(x) == (3, 4, 5)
     end
 
     @testset "param_draws" begin
         x = randn(100, 10)
-        @test PSIS.param_draws(x, 3) === view(x, :, 3)
+        @test PSIS.param_draws(x, CartesianIndex(3)) === view(x, :, 3)
 
         x = randn(100, 4, 10)
-        @test PSIS.param_draws(x, 5) === view(x, :, :, 5)
+        @test PSIS.param_draws(x, CartesianIndex(5)) === view(x, :, :, 5)
+
+        x = randn(100, 4, 5, 10)
+        @test PSIS.param_draws(x, CartesianIndex(5, 6)) === view(x, :, :, 5, 6)
+
+        x = randn(100, 4, 5, 6, 10)
+        @test PSIS.param_draws(x, CartesianIndex(5, 6, 7)) === view(x, :, :, 5, 6, 7)
     end
 
     @testset "sample_dims" begin


### PR DESCRIPTION
This PR improves support for multi-dimensional arrays and other specialized array types by using the `similar(A, T, axes)` pattern when constructing containers. This is more powerful when an array type has custom indices, so e.g. this works better for `OffsetArray` and `DimArray`, but arrays like `AxisArray` and `KeyedArray`, which don't implement custom indices, are less supported. :shrug:

This PR also allows the log-ratios to have the shape `(draw, chain, params...)`, which is useful e.g. in LOO-CV when log-likelihoods come in an array form. Then the pareto shape values have the param shapes and are more human-readable.