### PR TITLE
Tweaks to `fit_gpd` usage

### DIFF
--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -74,9 +74,14 @@ The fit is performed using the Empirical Bayes method of [^ZhangStephens2009].
 """
 function fit_gpd(x::AbstractArray; prior_adjusted::Bool=true, kwargs...)
     tail_dist = fit_gpd_empiricalbayes(x; kwargs...)
-    prior_adjusted || return tail_dist
-    return prior_adjust_shape(tail_dist, length(x))
+    if prior_adjusted && !_is_uniform(tail_dist)
+        return prior_adjust_shape(tail_dist, length(x))
+    else
+        return tail_dist
+    end
 end
+
+_is_uniform(d::GeneralizedPareto) = iszero(d.σ) && isone(-d.k)
 
 # Note: our k is ZhangStephens2009's -k, and our θ is ZhangStephens2009's -θ
 

--- a/src/generalized_pareto.jl
+++ b/src/generalized_pareto.jl
@@ -60,6 +60,8 @@ The fit is performed using the Empirical Bayes method of [^ZhangStephens2009].
 
 # Keywords
 
+  - `prior_adjusted::Bool=true`, If `true`, a weakly informative Normal prior centered on
+    ``\\frac{1}{2}`` is used for the shape ``k``.
   - `sorted::Bool=issorted(x)`: If `true`, `x` is assumed to be sorted. If `false`, a sorted
     copy of `x` is made.
   - `min_points::Int=30`: The minimum number of quadrature points to use when estimating the
@@ -70,7 +72,11 @@ The fit is performed using the Empirical Bayes method of [^ZhangStephens2009].
     Technometrics, 51:3, 316-325,
     DOI: [10.1198/tech.2009.08017](https://doi.org/10.1198/tech.2009.08017)
 """
-fit_gpd(x::AbstractArray; kwargs...) = fit_gpd_empiricalbayes(x; kwargs...)
+function fit_gpd(x::AbstractArray; prior_adjusted::Bool=true, kwargs...)
+    tail_dist = fit_gpd_empiricalbayes(x; kwargs...)
+    prior_adjusted || return tail_dist
+    return prior_adjust_shape(tail_dist, length(x))
+end
 
 # Note: our k is ZhangStephens2009's -k, and our θ is ZhangStephens2009's -θ
 

--- a/test/generalized_pareto.jl
+++ b/test/generalized_pareto.jl
@@ -13,6 +13,11 @@ using Test
             @test dhat.μ == μ
             @test dhat.σ ≈ σ atol = 0.01
             @test dhat.k ≈ k atol = 0.01
+            @test PSIS.fit_gpd(x; μ=μ, min_points=80) ==
+                PSIS.fit_gpd(x; prior_adjusted=true, μ=μ, min_points=80)
+            dhat2 = PSIS.fit_gpd(x; prior_adjusted=false, μ=μ, min_points=80)
+            @test dhat ≠ dhat2
+            @test dhat == PSIS.prior_adjust_shape(dhat2, length(x))
         end
         @testset "nearly uniform" begin
             x = ones(200_000)


### PR DESCRIPTION
This PR moves the prior adjustment option into  `fit_gpd` and updates `psis_tail!` to subtract the mean before calling `fit_gpd` so that the `tail_dist` always has 0 mean.

This is primarily useful for supporting diagnostics of generic expectations (see #21), where GPD might be fit to either or both tails. When fitting to the left tail, the tail is actually flipped to be a right tail before fitting GPD, so the returned mean is actually not useful.