### PR TITLE
Log-normalize log weights by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ JLD2 = "0.4"
 LogExpFunctions = "0.2.0, 0.3"
 Plots = "1"
 RecipesBase = "1"
-ReferenceTests = "0.9"
+ReferenceTests = "0.9, 0.10"
 julia = "1.6"
 
 [extras]

--- a/src/ess.jl
+++ b/src/ess.jl
@@ -28,8 +28,7 @@ function ess_is(r::PSISResult; bad_shape_missing::Bool=true)
 end
 function ess_is(weights; reff=1)
     dims = sample_dims(weights)
-    neff = broadcast_last_dims(/, reff, sum(abs2, weights; dims=dims))
-    return dropdims(neff; dims=dims)
+    return reff ./ dropdims(sum(abs2, weights; dims=dims); dims=dims)
 end
 ess_is(weights::AbstractVector; reff::Real=1) = reff / sum(abs2, weights)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,6 +31,13 @@ function sample_dims(x::AbstractArray)
 end
 sample_dims(::AbstractVector) = Colon()
 
+function _maybe_log_normalize!(x::AbstractArray, normalize::Bool)
+    if normalize
+        x .-= LogExpFunctions.logsumexp(x; dims=sample_dims(x))
+    end
+    return x
+end
+
 """
     broadcast_last_dims(f, x, y)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,28 +37,3 @@ function _maybe_log_normalize!(x::AbstractArray, normalize::Bool)
     end
     return x
 end
-
-"""
-    broadcast_last_dims(f, x, y)
-
-Compute `f.(x, y)` but where `y` shares the last dimensions of `x` instead of the first.
-
-This function adds leading singleton dimensions to `y` until it has the same number of
-dimensions as `x`.
-
-The function tries to keep the final array type as close as possible to the input type.
-"""
-function broadcast_last_dims(f, x, y)
-    (x isa Number || y isa Number || ndims(x) == ndims(y)) && return f.(x, y)
-    if ndims(x) > ndims(y)
-        yreshape = reshape(y, ntuple(one, ndims(x) - ndims(y))..., size(y)...)
-        z = f.(x, yreshape)
-        zdim = similar(x, eltype(z))
-    else
-        xreshape = reshape(x, ntuple(one, ndims(y) - ndims(x))..., size(x)...)
-        z = f.(xreshape, y)
-        zdim = similar(y, eltype(z))
-    end
-    copyto!(zdim, z)
-    return zdim
-end

--- a/test/ess.jl
+++ b/test/ess.jl
@@ -16,24 +16,21 @@ using Test
     @test ess_is(w; reff=reff) ≈ 1 .* reff
 
     logw = randn(100)
-    logw_norm = logsumexp(logw)
-    result = PSISResult(logw, logw_norm, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.6))
-    @test ess_is(result) ≈ ess_is(exp.(logw .- logw_norm); reff=1.5)
+    result = PSISResult(logw, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.6), false)
+    @test ess_is(result) ≈ ess_is(result.weights; reff=1.5)
 
-    result = PSISResult(logw, logw_norm, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.71))
+    result = PSISResult(logw, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.71), false)
     @test ismissing(ess_is(result))
-    @test ess_is(result; bad_shape_missing=false) ≈
-        ess_is(exp.(logw .- logw_norm); reff=1.5)
+    @test ess_is(result; bad_shape_missing=false) ≈ ess_is(result.weights; reff=1.5)
 
     logw = randn(100, 4, 3)
-    logw_norm = dropdims(logsumexp(logw; dims=(1, 2)); dims=(1, 2))
     tail_dists = [
         PSIS.GeneralizedPareto(0.0, 1.0, 0.69),
         PSIS.GeneralizedPareto(0.0, 1.0, 0.71),
         missing,
     ]
     reff = [1.5, 0.8, 1.0]
-    result = PSISResult(logw, logw_norm, reff, [20, 20, 20], tail_dists)
+    result = PSISResult(logw, reff, [20, 20, 20], tail_dists, false)
     ess = ess_is(result)
     @test ess isa Vector
     @test length(ess) == 3

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -39,21 +39,4 @@ using DimensionalData: Dimensions, DimArray
         x = randn(100, 4, 10)
         @test PSIS.sample_dims(x) === (1, 2)
     end
-
-    @testset "broadcast_last_dims" begin
-        adim = Dimensions.Dim{:a}([Symbol("a[$i]") for i in 1:2])
-        bdim = Dimensions.Dim{:b}([Symbol("b[$i]") for i in 1:10])
-        x = DimArray(randn(2, 10), (adim, bdim))
-        y = DimArray(randn(10), (bdim,))
-        @test @inferred(PSIS.broadcast_last_dims(/, x[1, :], y)) == x[1, :] ./ y
-        @test @inferred(PSIS.broadcast_last_dims(/, x, y)) == x ./ reshape(y, 1, :)
-        @test @inferred(PSIS.broadcast_last_dims(/, y, x)) == reshape(y, 1, :) ./ x
-        @test @inferred(PSIS.broadcast_last_dims(/, x, 3)) == x ./ 3
-        @test @inferred(PSIS.broadcast_last_dims(/, 4, x)) == 4 ./ x
-
-        @test PSIS.broadcast_last_dims(/, x, y) isa DimArray
-        @test Dimensions.dims(PSIS.broadcast_last_dims(/, x, y)) == Dimensions.dims(x)
-        @test PSIS.broadcast_last_dims(/, y, x) isa DimArray
-        @test Dimensions.dims(PSIS.broadcast_last_dims(/, y, x)) == Dimensions.dims(x)
-    end
 end


### PR DESCRIPTION
This PR removes the `log_weights_norm` parameter from `r::PSISResult` and adds a `normalize` kwarg, which is used to log-normalize the log-weights if `true`. Either way, `r.weights` is always normalized, but it isn't renormalized if `normalize==true`.