### PR TITLE
Support array inputs of shape `(draws, [chains[, parameters...]])`

### DIFF
--- a/src/ess.jl
+++ b/src/ess.jl
@@ -27,10 +27,9 @@ function ess_is(r::PSISResult; bad_shape_missing::Bool=true)
     return _apply_missing(neff, r.tail_dist; bad_shape_missing=bad_shape_missing)
 end
 function ess_is(weights; reff=1)
-    dims = sample_dims(weights)
+    dims = _sample_dims(weights)
     return reff ./ dropdims(sum(abs2, weights; dims=dims); dims=dims)
 end
-ess_is(weights::AbstractVector; reff::Real=1) = reff / sum(abs2, weights)
 
 function _apply_missing(neff, dist; bad_shape_missing)
     return bad_shape_missing && pareto_shape(dist) > 0.7 ? missing : neff

--- a/test/core.jl
+++ b/test/core.jl
@@ -78,7 +78,7 @@ using DimensionalData: Dimensions, DimArray
             proposal = Normal()
             target = TDist(7)
             rng = MersenneTwister(42)
-            x = rand(rng, proposal, 100, 30)
+            x = rand(rng, proposal, 100, 1, 30)
             log_ratios = logpdf.(target, x) .- logpdf.(proposal, x)
             reff = [100; ones(29)]
             result = psis(log_ratios, reff)
@@ -110,8 +110,8 @@ end
         ]
             proposal = Exponential(θ)
             k_exp = 1 - θ
-            for sz in ((100_000,), (100_000, 5), (100_000, 4, 5))
-                dims = length(sz) == 1 ? Colon() : 1:(length(sz) - 1)
+            for sz in ((100_000,), (100_000, 4), (100_000, 4, 5))
+                dims = length(sz) < 3 ? Colon() : 1:(length(sz) - 1)
                 rng = MersenneTwister(42)
                 x = rand(rng, proposal, sz)
                 logr = logpdf.(target, x) .- logpdf.(proposal, x)
@@ -126,16 +126,16 @@ end
                 @test !(r2.log_weights ≈ r.log_weights)
                 @test r2.weights ≈ r.weights
 
-                if length(sz) == 3
+                if length(sz) > 1
                     @test all(r.tail_length .== PSIS.tail_length(1, 400_000))
                 else
                     @test all(r.tail_length .== PSIS.tail_length(1, 100_000))
                 end
 
                 k = r.pareto_shape
-                @test k isa (length(sz) == 1 ? Number : AbstractVector)
+                @test k isa (length(sz) < 3 ? Number : AbstractVector)
                 tail_dist = r.tail_dist
-                if length(sz) == 1
+                if length(sz) < 3
                     @test tail_dist isa PSIS.GeneralizedPareto
                     @test tail_dist.k == k
                 else

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -49,7 +49,7 @@ using Test
     end
 
     @testset "plot(::PSISResult; seriestype=:path)" begin
-        result = psis(randn(100, 10))
+        result = psis(randn(100, 2, 10))
         plt = plot(result; seriestype=:path)
         @test length(plt.series_list) == 1
         @test plt[1][1][:x] == eachindex(result.pareto_shape)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,40 +3,51 @@ using Test
 using DimensionalData: Dimensions, DimArray
 
 @testset "utils" begin
-    @testset "param_dim" begin
-        x = randn(100, 10)
-        @test PSIS.param_dims(x) == (2,)
-
-        x = randn(100, 4, 10)
-        @test PSIS.param_dims(x) == (3,)
-
-        x = randn(100, 4, 5, 10)
-        @test PSIS.param_dims(x) == (3, 4)
-
-        x = randn(100, 4, 5, 6, 10)
-        @test PSIS.param_dims(x) == (3, 4, 5)
-    end
-
-    @testset "param_draws" begin
-        x = randn(100, 10)
-        @test PSIS.param_draws(x, CartesianIndex(3)) === view(x, :, 3)
-
-        x = randn(100, 4, 10)
-        @test PSIS.param_draws(x, CartesianIndex(5)) === view(x, :, :, 5)
-
-        x = randn(100, 4, 5, 10)
-        @test PSIS.param_draws(x, CartesianIndex(5, 6)) === view(x, :, :, 5, 6)
-
-        x = randn(100, 4, 5, 6, 10)
-        @test PSIS.param_draws(x, CartesianIndex(5, 6, 7)) === view(x, :, :, 5, 6, 7)
-    end
-
-    @testset "sample_dims" begin
+    @testset "_param_dims" begin
         x = randn(100)
-        @test PSIS.sample_dims(x) === Colon()
+        @test PSIS._param_dims(x) == ()
+
         x = randn(100, 10)
-        @test PSIS.sample_dims(x) === (1,)
+        @test PSIS._param_dims(x) == ()
+
         x = randn(100, 4, 10)
-        @test PSIS.sample_dims(x) === (1, 2)
+        @test PSIS._param_dims(x) == (3,)
+
+        x = randn(100, 4, 5, 10)
+        @test PSIS._param_dims(x) == (3, 4)
+
+        x = randn(100, 4, 5, 6, 10)
+        @test PSIS._param_dims(x) == (3, 4, 5)
+    end
+
+    @testset "_eachparamindex/_selectparam" begin
+        x = randn(100)
+        @test size(PSIS._eachparamindex(x)) == ()
+        @test PSIS._selectparam(x, PSIS._eachparamindex(x)[1]) == x
+
+        x = randn(100, 4)
+        @test size(PSIS._eachparamindex(x)) == ()
+        @test PSIS._selectparam(x, PSIS._eachparamindex(x)[1]) == x
+
+        x = randn(100, 4, 5)
+        @test size(PSIS._eachparamindex(x)) == (5,)
+        @test PSIS._selectparam.(Ref(x), PSIS._eachparamindex(x)) ==
+            collect(eachslice(x; dims=3))
+
+        x = randn(100, 4, 5, 3)
+        @test size(PSIS._eachparamindex(x)) == (5, 3)
+        if VERSION ≥ v"1.9"
+            @test PSIS._selectparam.(Ref(x), PSIS._eachparamindex(x)) ==
+                eachslice(x; dims=(3, 4))
+        end
+    end
+
+    @testset "_sample_dims" begin
+        x = randn(100)
+        @test PSIS._sample_dims(x) === (1,)
+        x = randn(100, 10)
+        @test PSIS._sample_dims(x) === (1, 2)
+        x = randn(100, 4, 10)
+        @test PSIS._sample_dims(x) === (1, 2)
     end
 end


### PR DESCRIPTION
Follows the same approach as in https://github.com/TuringLang/MCMCDiagnosticTools.jl/pull/79