### PR TITLE
Stop returning missing for failured GPD fits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.8.0"
+version = "0.9.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/core.jl
+++ b/test/core.jl
@@ -90,7 +90,7 @@ using DimensionalData: Dimensions, DimArray
                   (0.5, 0.7]  okay       6 (20.0%)  92
                     (0.7, 1]  bad        4 (13.3%)  ——
                     (1, Inf)  very bad  17 (56.7%)  ——
-                          ——  missing    1 (3.3%)   ——"""
+                          ——  failed     1 (3.3%)   ——"""
         end
     end
 end
@@ -160,8 +160,8 @@ end
             psis(logr; normalize=false)
         end
         @test result.log_weights == logr
-        @test ismissing(result.tail_dist)
-        @test ismissing(result.pareto_shape)
+        @test isnan(result.tail_dist.σ)
+        @test isnan(result.pareto_shape)
         msg = String(take!(io))
         @test occursin(
             "Warning: 1 tail draws is insufficient to fit the generalized Pareto distribution.",
@@ -180,8 +180,8 @@ end
                 psis(logr; normalize=false)
             end
             @test skipnan(result.log_weights) == skipnan(logr)
-            @test ismissing(result.tail_dist)
-            @test ismissing(result.pareto_shape)
+            @test isnan(result.tail_dist.σ)
+            @test isnan(result.pareto_shape)
             msg = String(take!(io))
             @test occursin("Warning: Tail contains non-finite values.", msg)
         end
@@ -226,7 +226,7 @@ end
         @test isempty(msg)
 
         tail_dist = [
-            missing,
+            PSIS.GeneralizedPareto(0, NaN, NaN),
             PSIS.GeneralizedPareto(0, 1, 0.69),
             PSIS.GeneralizedPareto(0, 1, 0.71),
             PSIS.GeneralizedPareto(0, 1, 1.1),

--- a/test/core.jl
+++ b/test/core.jl
@@ -116,7 +116,7 @@ end
                 x = rand(rng, proposal, sz)
                 logr = logpdf.(target, x) .- logpdf.(proposal, x)
 
-                r = psis(logr)
+                r = @inferred psis(logr)
                 @test r isa PSISResult
                 logw = r.log_weights
                 @test logw isa typeof(logr)
@@ -260,7 +260,7 @@ end
         logr = permutedims(logr, (2, 3, 1))
         @testset for r_eff in (0.7, 1.2)
             r_effs = fill(r_eff, sz[1])
-            result = psis(logr, r_effs; normalize=false)
+            result = @inferred psis(logr, r_effs; normalize=false)
             logw = result.log_weights
             @test !isapprox(logw, logr)
             basename = "normal_to_cauchy_reff_$(r_eff)"
@@ -295,7 +295,7 @@ end
                     Dimensions.Dim{:param}(param_names),
                 ),
             )
-            result = psis(logr)
+            result = @inferred psis(logr)
             @test result.log_weights isa DimArray
             @test Dimensions.dims(result.log_weights) == Dimensions.dims(logr)
             for k in (:pareto_shape, :tail_length, :tail_dist, :reff)

--- a/test/ess.jl
+++ b/test/ess.jl
@@ -20,14 +20,14 @@ using Test
     @test ess_is(result) ≈ ess_is(result.weights; reff=1.5)
 
     result = PSISResult(logw, 1.5, 20, PSIS.GeneralizedPareto(0.0, 1.0, 0.71), false)
-    @test ismissing(ess_is(result))
-    @test ess_is(result; bad_shape_missing=false) ≈ ess_is(result.weights; reff=1.5)
+    @test isnan(ess_is(result))
+    @test ess_is(result; bad_shape_nan=false) ≈ ess_is(result.weights; reff=1.5)
 
     logw = randn(100, 4, 3)
     tail_dists = [
         PSIS.GeneralizedPareto(0.0, 1.0, 0.69),
         PSIS.GeneralizedPareto(0.0, 1.0, 0.71),
-        missing,
+        PSIS.GeneralizedPareto(0.0, NaN, NaN),
     ]
     reff = [1.5, 0.8, 1.0]
     result = PSISResult(logw, reff, [20, 20, 20], tail_dists, false)
@@ -35,9 +35,8 @@ using Test
     @test ess isa Vector
     @test length(ess) == 3
     @test ess[1] ≈ ess_is(result.weights; reff=reff)[1]
-    @test ismissing(ess[2])
-    @test ismissing(ess[3])
-    ess = ess_is(result; bad_shape_missing=false)
-    @test ess[1:2] ≈ ess_is(result.weights; reff=reff)[1:2]
-    @test ismissing(ess[3])
+    @test isnan(ess[2])
+    @test isnan(ess[3])
+    ess = ess_is(result; bad_shape_nan=false)
+    @test ess ≈ ess_is(result.weights; reff=reff)[1:3]
 end


### PR DESCRIPTION
Currently when we cannot fit a GPD distribution, we set `tail_dist` and `pareto_shape` to `missing`. Because GPD failures are determined by value, not type, this makes the return type of `psis!` uninferrable. While the resulting type-union is only of size 2, it's quite annoying for downstream tasks to have to special-case for this type union.

This PR replaces this `missing` with a GPD with `NaN` for the shape and scale parameters. For user code that did not do anything special to handle potential `missing`s, nothing would need to change. Nevertheless, this is a breaking change.