### PR TITLE
Fix dimensions in documented examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,7 +20,8 @@ Random.seed!(42) # hide
 using PSIS, Distributions
 proposal = Normal()
 target = TDist(7)
-x = rand(proposal, 1_000, 30)
+ndraws, nchains, nparams = (1_000, 1, 30)
+x = rand(proposal, ndraws, nchains, nparams)
 log_ratios = logpdf.(target, x) .- logpdf.(proposal, x)
 result = psis(log_ratios)
 nothing # hide

--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -10,7 +10,8 @@ Random.seed!(42) # hide
 using PSIS, Distributions
 proposal = Normal()
 target = TDist(7)
-x = rand(proposal, 1_000, 20)
+ndraws, nchains, nparams = (1_000, 1, 20)
+x = rand(proposal, ndraws, nchains, nparams)
 log_ratios = logpdf.(target, x) .- logpdf.(proposal, x)
 result = psis(log_ratios)
 ```


### PR DESCRIPTION
The documented examples were still using the old dimensions `(draws, params)` instead of the new ones `(draws[, chains[, params]])`. This PR fixes this.