### PR TITLE
Bump test dependency compats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DimensionalData = "0.24.2"
+DimensionalData = "0.24.2, 0.25, 0.26, 0.27, 0.28, 0.29"
 Distributions = "0.25.81"
 JLD2 = "0.4.28, 0.5"
 LinearAlgebra = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSIS"
 uuid = "ce719bf2-d5d0-4fb9-925d-10a81b42ad04"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 DimensionalData = "0.24.2"
 Distributions = "0.25.81"
-JLD2 = "0.4.28"
+JLD2 = "0.4.28, 0.5"
 LinearAlgebra = "1.6"
 LogExpFunctions = "0.3.3"
 Plots = "1.10.1"


### PR DESCRIPTION
Since CompatHelper doesn't touch test-only dependency compat entries, this PR updates the compat entries for JLD2 and DimensionalData.