### PR TITLE
ci: fix Downgrade docs job by forcing Pkg.build()

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -62,6 +62,7 @@ jobs:
           projects: ., docs
           julia_version: ${{ steps['setup-julia'].outputs.julia-version }}
       - uses: julia-actions/julia-buildpkg@v1
+      - run: julia --project=docs -e 'using Pkg; Pkg.build()'
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The `Downgrade` workflow's docs job has been failing since 2026-04-01 with `could not load library "libGR.so"`. The downgrade-compat resolver pins `Plots` to its floor (`1.10.1`), which forces a legacy, pre-`GR_jll` `GR` version that needs a custom build step to fetch its native binary — but that build step never runs in this pipeline, so the binary is missing. Adding an explicit `Pkg.build()` for the `docs` project closes the gap.

## Test plan
- [x] Downgrade workflow's `Documentation` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>