### PR TITLE
ci: simplify Downgrade workflow

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,22 +15,20 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.11'
+          - 'lts'
         os: ['ubuntu-latest']
         num_threads: [1, 2]
 
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
-        id: setup-julia
         with:
           version: ${{ matrix.version }}
           arch: x64
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
-          skip: LinearAlgebra,Printf,Statistics
-          julia_version: ${{ steps['setup-julia'].outputs.julia-version }}
+          mode: deps
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         with:
@@ -42,28 +40,3 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           file: lcov.info
-
-  docs:
-    name: Documentation - Julia ${{ matrix.version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ['1.11']
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        id: setup-julia
-        with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: LinearAlgebra,Printf,PSIS,Statistics
-          projects: ., docs
-          julia_version: ${{ steps['setup-julia'].outputs.julia-version }}
-      - uses: julia-actions/julia-buildpkg@v1
-      - run: julia --project=docs -e 'using Pkg; Pkg.build()'
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GKSwstype: "100"


### PR DESCRIPTION
- Drop the docs job (downgrade testing only needs to cover the test suite, not docs builds)
- Track Julia \`lts\` instead of a hardcoded version
- Drop \`skip\`/\`julia_version\` inputs, set \`mode: deps\` explicitly instead